### PR TITLE
Gracefully handle gpx without trk name

### DIFF
--- a/src/events/adapters/importers/gpx/importer.gpx.spec.ts
+++ b/src/events/adapters/importers/gpx/importer.gpx.spec.ts
@@ -1,0 +1,49 @@
+import { EventImporterGPX } from './importer.gpx';
+
+describe("importer.gpx", () => {
+
+    it("parses gpx without name", async () => {
+        const gpxString = `<?xml version="1.0" encoding="UTF-8"?>
+        <gpx creator="Garmin Connect" version="1.1"
+          xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/11.xsd"
+          xmlns:ns3="http://www.garmin.com/xmlschemas/TrackPointExtension/v1"
+          xmlns="http://www.topografix.com/GPX/1/1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns2="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+          <metadata>
+            <link href="connect.garmin.com">
+              <text>Garmin Connect</text>
+            </link>
+            <time>2019-09-29T13:58:25.000Z</time>
+          </metadata>
+          <trk>
+            <type>road_biking</type>
+          </trk>
+        </gpx> `;
+
+        const result = await EventImporterGPX.getFromString(gpxString);
+        expect(result.getFirstActivity().name).toEqual("");
+    });
+
+    it("parses gpx with name", async () => {
+        const gpxString = `<?xml version="1.0" encoding="UTF-8"?>
+        <gpx creator="Garmin Connect" version="1.1"
+          xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/11.xsd"
+          xmlns:ns3="http://www.garmin.com/xmlschemas/TrackPointExtension/v1"
+          xmlns="http://www.topografix.com/GPX/1/1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns2="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+          <metadata>
+            <link href="connect.garmin.com">
+              <text>Garmin Connect</text>
+            </link>
+            <time>2019-09-29T13:58:25.000Z</time>
+          </metadata>
+          <trk>
+            <name>Meylan Road Cycling</name>
+            <type>road_biking</type>
+          </trk>
+        </gpx> `;
+
+        const result = await EventImporterGPX.getFromString(gpxString);
+        expect(result.getFirstActivity().name).toEqual("Meylan Road Cycling");
+    });
+})

--- a/src/events/adapters/importers/gpx/importer.gpx.ts
+++ b/src/events/adapters/importers/gpx/importer.gpx.ts
@@ -58,6 +58,7 @@ export class EventImporterGPX {
             activityType = ActivityTypes[<keyof typeof ActivityTypes>entryFound.type];
           }
         }*/
+        const activityName =  trackOrRoute.name?.[0] || "";
         const activity = new Activity(
           startDate,
           endDate,
@@ -66,7 +67,7 @@ export class EventImporterGPX {
             parsedGPX.creator,
             parsedGPX.version,
           ),
-          trackOrRoute.name[0]
+          activityName
         );
         // Match
         GPXSampleMapper.forEach((sampleMapping) => {


### PR DESCRIPTION
Fix to ensure gpx files without a name don't cause a parsing error