### PR TITLE
Prettier config

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "generate:docs": "npm run build && typedoc --out docs --target es6 --theme minimal --mode file src",
     "lint:fix": "node ./node_modules/tslint/bin/tslint -c ./tslint.json ./**/*.ts --fix",
     "test": "jest",
-    "test-coverage": "jest --coverage"
+    "test-coverage": "jest --coverage",
+    "prettier:fix": "prettier --write ."
   },
   "repository": {
     "type": "git",
@@ -55,6 +56,7 @@
     "@types/jest": "^26.0.10",
     "@types/xmldom": "^0.1.30",
     "jest": "^26.4.2",
+    "prettier": "^2.1.2",
     "ts-jest": "^26.3.0",
     "tslint": "^6.1.3",
     "typedoc": "^0.18.0",
@@ -79,5 +81,8 @@
         "babelConfig": true
       }
     }
+  },
+  "prettier": {
+    "singleQuote": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2912,6 +2912,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
+  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
+
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"


### PR DESCRIPTION
Prettier config that roughly matches existing code so developers don't need to disable auto prettier-format on save in editors.
yarn prettier:fix hasn't been run yet to avoid a large PR.