### PR TITLE
fix: make long FIT activity parsing linear and memory efficient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@googlemaps/polyline-codec": "^1.0.28",
         "fast-xml-parser": "^5.3.3",
-        "fit-file-parser": "^3.1.3",
+        "fit-file-parser": "^4.0.0",
         "geolib": "^3.3.4",
         "gpx-builder": "^3.7.8",
         "kalmanjs": "^1.1.0",
@@ -4842,9 +4842,9 @@
       }
     },
     "node_modules/fit-file-parser": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fit-file-parser/-/fit-file-parser-3.1.3.tgz",
-      "integrity": "sha512-nCis2UScyDXS43tL256QrFmhGiihnMUx7PUDl3S9GuWQRTLHhJF59YZeNoX7ycLhfZ4vbhMPbiDaWFbdWYn0mw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fit-file-parser/-/fit-file-parser-4.0.0.tgz",
+      "integrity": "sha512-B7Ym9rdttX2ZjHFEmLXLG/1tPiRdMDfTNLFjGRlc+HAWrsKsV47lq0kQWAlGGtLSdfEqutjUu1D3KXhks4FmCw==",
       "dependencies": {
         "buffer": "^6.0.3"
       }
@@ -11182,9 +11182,9 @@
       }
     },
     "fit-file-parser": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fit-file-parser/-/fit-file-parser-3.1.3.tgz",
-      "integrity": "sha512-nCis2UScyDXS43tL256QrFmhGiihnMUx7PUDl3S9GuWQRTLHhJF59YZeNoX7ycLhfZ4vbhMPbiDaWFbdWYn0mw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fit-file-parser/-/fit-file-parser-4.0.0.tgz",
+      "integrity": "sha512-B7Ym9rdttX2ZjHFEmLXLG/1tPiRdMDfTNLFjGRlc+HAWrsKsV47lq0kQWAlGGtLSdfEqutjUu1D3KXhks4FmCw==",
       "requires": {
         "buffer": "^6.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@googlemaps/polyline-codec": "^1.0.28",
     "fast-xml-parser": "^5.3.3",
-    "fit-file-parser": "^3.1.3",
+    "fit-file-parser": "^4.0.0",
     "geolib": "^3.3.4",
     "gpx-builder": "^3.7.8",
     "kalmanjs": "^1.1.0",

--- a/src/activities/activity.ts
+++ b/src/activities/activity.ts
@@ -335,13 +335,23 @@ export class Activity extends DurationClassAbstract implements ActivityInterface
     const timeStream = new Stream(DataTime.type, Array(this.getTimeGridLength(streams)).fill(null));
     const timeStreamData = timeStream.getData();
     streams.forEach(stream => {
-      this.getStreamDataByDuration(stream.type, true, false).forEach((data: StreamDataItem) => {
-        const timeIndex =
-          stream.type === DataIBI.type ? Activity.projectMillisecondsToSecondGrid(data.time) : data.time / 1000;
-        if (Number.isInteger(timeIndex) && timeIndex >= 0 && timeIndex < timeStreamData.length) {
-          timeStreamData[timeIndex] = timeIndex;
+      if (stream.type === DataIBI.type) {
+        this.getStreamDataByDuration(stream.type, true, false).forEach((data: StreamDataItem) => {
+          const timeIndex = Activity.projectMillisecondsToSecondGrid(data.time);
+          if (Number.isInteger(timeIndex) && timeIndex >= 0 && timeIndex < timeStreamData.length) {
+            timeStreamData[timeIndex] = timeIndex;
+          }
+        });
+        return;
+      }
+
+      const streamData = stream.getData();
+      const dataLength = Math.min(streamData.length, timeStreamData.length);
+      for (let index = 0; index < dataLength; index++) {
+        if (isNumber(streamData[index])) {
+          timeStreamData[index] = index;
         }
-      });
+      }
     });
     return timeStream;
   }

--- a/src/events/adapters/importers/fit/importer.fit.spec.ts
+++ b/src/events/adapters/importers/fit/importer.fit.spec.ts
@@ -49,6 +49,45 @@ describe('EventImporterFIT', () => {
       expect(beta).toHaveBeenCalledTimes(samples.length);
       expect(missing).toHaveBeenCalledTimes(samples.length);
     });
+
+    it('preserves sparse sample-array behavior', () => {
+      const activity = new Activity(new Date(0), new Date(3000), ActivityTypes.Running, new Creator('Test'));
+      activity.addStream(activity.createStream(DataDuration.type));
+      const samples = new Array<any>(4);
+      samples[0] = { timestamp: new Date(0), value: 1 };
+      samples[2] = { timestamp: new Date(2000), value: 3 };
+      const mapper = jest.fn((sample: any) => sample.value);
+
+      (EventImporterFIT as any).addSampleStreamsToActivity(
+        activity,
+        samples,
+        [{ dataType: 'Sparse', getSampleValue: mapper }],
+        { hasPowerMeter: false }
+      );
+
+      expect(activity.getStreamData('Sparse')).toEqual([1, null, 3, null]);
+      expect(mapper).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not read timestamps for samples that produce no stream values', () => {
+      const activity = new Activity(new Date(0), new Date(1000), ActivityTypes.Running, new Creator('Test'));
+      const timestampGetter = jest.fn(() => new Date(0));
+      const sample = {
+        get timestamp() {
+          return timestampGetter();
+        }
+      };
+
+      (EventImporterFIT as any).addSampleStreamsToActivity(
+        activity,
+        [sample],
+        [{ dataType: 'Missing', getSampleValue: () => null }],
+        { hasPowerMeter: false }
+      );
+
+      expect(timestampGetter).not.toHaveBeenCalled();
+      expect(activity.hasStreamData('Missing')).toBe(false);
+    });
   });
 
   describe('Session normalization', () => {

--- a/src/events/adapters/importers/fit/importer.fit.spec.ts
+++ b/src/events/adapters/importers/fit/importer.fit.spec.ts
@@ -14,6 +14,43 @@ import { Activity } from '../../../../activities/activity';
 import { Creator } from '../../../../creators/creator';
 
 describe('EventImporterFIT', () => {
+  describe('Sample stream construction', () => {
+    it('maps each sample once, preserves mapping order, and keeps the last duplicate timestamp value', () => {
+      const activity = new Activity(new Date(0), new Date(3000), ActivityTypes.Running, new Creator('Test'));
+      activity.addStream(activity.createStream(DataDuration.type));
+
+      const samples = [
+        { timestamp: new Date(0), alpha: 1 },
+        { timestamp: new Date(1000), alpha: 2, beta: 10 },
+        { timestamp: new Date(1000), alpha: 3, beta: 20 },
+        { timestamp: new Date(2000), alpha: Number.NaN, beta: Infinity },
+        { timestamp: new Date(3000) }
+      ];
+      const alpha = jest.fn((sample: any) => sample.alpha);
+      const beta = jest.fn((sample: any) => sample.beta);
+      const missing = jest.fn(() => null);
+
+      (EventImporterFIT as any).addSampleStreamsToActivity(
+        activity,
+        samples,
+        [
+          { dataType: 'Alpha', getSampleValue: alpha },
+          { dataType: 'Beta', getSampleValue: beta },
+          { dataType: 'Missing', getSampleValue: missing }
+        ],
+        { hasPowerMeter: false }
+      );
+
+      expect(activity.getAllStreams().map(stream => stream.type)).toEqual([DataDuration.type, 'Alpha', 'Beta']);
+      expect(activity.getStreamData('Alpha')).toEqual([1, 3, null, null]);
+      expect(activity.getStreamData('Beta')).toEqual([null, 20, Infinity, null]);
+      expect(activity.hasStreamData('Missing')).toBe(false);
+      expect(alpha).toHaveBeenCalledTimes(samples.length);
+      expect(beta).toHaveBeenCalledTimes(samples.length);
+      expect(missing).toHaveBeenCalledTimes(samples.length);
+    });
+  });
+
   describe('Session normalization', () => {
     it('should synthesize a fallback session when sessions are missing but top-level messages exist', () => {
       const startDate = new Date('2026-03-06T08:14:19.000Z');

--- a/src/events/adapters/importers/fit/importer.fit.spec.ts
+++ b/src/events/adapters/importers/fit/importer.fit.spec.ts
@@ -69,6 +69,41 @@ describe('EventImporterFIT', () => {
       expect(mapper).toHaveBeenCalledTimes(2);
     });
 
+    it('caches timestamp indexes across mappings and accepts supported timestamp representations', () => {
+      const startDate = new Date('2023-03-01T09:00:45.000Z');
+      const activity = new Activity(
+        startDate,
+        new Date(startDate.getTime() + 3000),
+        ActivityTypes.Running,
+        new Creator('Test')
+      );
+      const samples = [
+        { timestamp: startDate.toISOString(), alpha: 1, beta: 10 },
+        { timestamp: startDate.getTime() + 1000, alpha: 2, beta: 20 },
+        { timestamp: new Date(startDate.getTime() + 2000), alpha: 3, beta: 30 }
+      ];
+      const getDateIndex = jest.spyOn(activity, 'getDateIndex');
+
+      (EventImporterFIT as any).addSampleStreamsToActivity(
+        activity,
+        samples,
+        [
+          { dataType: 'Alpha', getSampleValue: (sample: any) => sample.alpha },
+          { dataType: 'Beta', getSampleValue: (sample: any) => sample.beta }
+        ],
+        { hasPowerMeter: false }
+      );
+
+      expect(activity.getStreamData('Alpha')).toEqual([1, 2, 3, null]);
+      expect(activity.getStreamData('Beta')).toEqual([10, 20, 30, null]);
+      expect(getDateIndex).toHaveBeenCalledTimes(samples.length);
+      expect(getDateIndex.mock.calls.map(([date]) => date.getTime())).toEqual([
+        startDate.getTime(),
+        startDate.getTime() + 1000,
+        startDate.getTime() + 2000
+      ]);
+    });
+
     it('does not read timestamps for samples that produce no stream values', () => {
       const activity = new Activity(new Date(0), new Date(1000), ActivityTypes.Running, new Creator('Test'));
       const timestampGetter = jest.fn(() => new Date(0));

--- a/src/events/adapters/importers/fit/importer.fit.ts
+++ b/src/events/adapters/importers/fit/importer.fit.ts
@@ -196,18 +196,15 @@ export class EventImporterFIT {
     samplesInfo: SampleInfo
   ): void {
     const sampleIndexes = new Array<number>(samples.length);
-    for (let samplePosition = 0; samplePosition < samples.length; samplePosition++) {
-      const timestamp = samples[samplePosition].timestamp;
-      sampleIndexes[samplePosition] = activity.getDateIndex(
-        timestamp instanceof Date ? timestamp : new Date(timestamp)
-      );
-    }
 
     for (const sampleMapping of sampleMappings) {
       let stream: StreamInterface | undefined;
       let streamData: (number | null)[] | undefined;
 
       for (let samplePosition = 0; samplePosition < samples.length; samplePosition++) {
+        if (!(samplePosition in samples)) {
+          continue;
+        }
         const value = sampleMapping.getSampleValue(samples[samplePosition], samplesInfo);
         if (!isNumber(value)) {
           continue;
@@ -216,6 +213,12 @@ export class EventImporterFIT {
         if (!stream) {
           stream = activity.createStream(sampleMapping.dataType);
           streamData = stream.getData();
+        }
+        if (!(samplePosition in sampleIndexes)) {
+          const timestamp = samples[samplePosition].timestamp;
+          sampleIndexes[samplePosition] = activity.getDateIndex(
+            timestamp instanceof Date ? timestamp : new Date(timestamp)
+          );
         }
         streamData![sampleIndexes[samplePosition]] = value;
       }
@@ -1082,9 +1085,7 @@ export class EventImporterFIT {
       const recoveredStartDate =
         firstRecordTimestamp ||
         (activity.startDate < rawEndDate ? activity.startDate : null) ||
-        (totalElapsedTime && totalElapsedTime > 0
-          ? new Date(rawEndDate.getTime() - totalElapsedTime * 1000)
-          : null);
+        (totalElapsedTime && totalElapsedTime > 0 ? new Date(rawEndDate.getTime() - totalElapsedTime * 1000) : null);
 
       if (recoveredStartDate && recoveredStartDate < rawEndDate) {
         return {
@@ -1135,9 +1136,7 @@ export class EventImporterFIT {
 
     return {
       startDate: activity.startDate,
-      endDate: activity.endDate > activity.startDate
-        ? activity.endDate
-        : new Date(activity.startDate.getTime() + 1000)
+      endDate: activity.endDate > activity.startDate ? activity.endDate : new Date(activity.startDate.getTime() + 1000)
     };
   }
 

--- a/src/events/adapters/importers/fit/importer.fit.ts
+++ b/src/events/adapters/importers/fit/importer.fit.ts
@@ -176,7 +176,9 @@ import {
   isStreamTypeAllowedForImport,
   pruneActivityStreamsBySelection
 } from '../../../../streams/stream.selection';
+import { StreamInterface } from '../../../../streams/stream.interface';
 import { StatsUtilities } from '../../../../stats/stats.utilities';
+import { SampleInfo } from '../sample-info.interface';
 
 // Threshold to detect that session.timestamp are not trustable (when exceeding 15% of session.total_elapsed_time)
 const INVALID_DATES_ELAPSED_TIME_RATIO_THRESHOLD = 1.15;
@@ -186,6 +188,43 @@ export class EventImporterFIT {
   private static readonly INVALID_FIT_HRV_INTERVAL_MS = 65535;
   private static readonly MIN_VALID_VO2_MAX = 10;
   private static readonly MAX_VALID_VO2_MAX = 100;
+
+  private static addSampleStreamsToActivity(
+    activity: ActivityInterface,
+    samples: any[],
+    sampleMappings: typeof FITSampleMapper,
+    samplesInfo: SampleInfo
+  ): void {
+    const sampleIndexes = new Array<number>(samples.length);
+    for (let samplePosition = 0; samplePosition < samples.length; samplePosition++) {
+      const timestamp = samples[samplePosition].timestamp;
+      sampleIndexes[samplePosition] = activity.getDateIndex(
+        timestamp instanceof Date ? timestamp : new Date(timestamp)
+      );
+    }
+
+    for (const sampleMapping of sampleMappings) {
+      let stream: StreamInterface | undefined;
+      let streamData: (number | null)[] | undefined;
+
+      for (let samplePosition = 0; samplePosition < samples.length; samplePosition++) {
+        const value = sampleMapping.getSampleValue(samples[samplePosition], samplesInfo);
+        if (!isNumber(value)) {
+          continue;
+        }
+
+        if (!stream) {
+          stream = activity.createStream(sampleMapping.dataType);
+          streamData = stream.getData();
+        }
+        streamData![sampleIndexes[samplePosition]] = value;
+      }
+
+      if (stream) {
+        activity.addStream(stream);
+      }
+    }
+  }
 
   static async getFromArrayBuffer(
     arrayBuffer: ArrayBuffer | Buffer<ArrayBuffer>,
@@ -472,24 +511,7 @@ export class EventImporterFIT {
             ) !== -1;
           const samplesInfo = { hasPowerMeter: hasPowerMeter };
 
-          allowedSampleMappings.forEach(sampleMapping => {
-            // @todo not sure if we need to check for number only ...
-            const subjectSamples = <any[]>(
-              samples.filter((sample: any) => isNumber(sampleMapping.getSampleValue(sample, samplesInfo)))
-            );
-            if (subjectSamples.length) {
-              // When we create a stream here it has the length of the activity elapsed time (end-start) filled with nulls.
-              // We keep nulls in order to preserve the array length.
-              activity.addStream(activity.createStream(sampleMapping.dataType));
-              subjectSamples.forEach(subjectSample => {
-                activity.addDataToStream(
-                  sampleMapping.dataType,
-                  new Date(subjectSample.timestamp),
-                  <number>sampleMapping.getSampleValue(subjectSample, samplesInfo)
-                );
-              });
-            }
-          });
+          this.addSampleStreamsToActivity(activity, samples, allowedSampleMappings, samplesInfo);
 
           return activity;
         });

--- a/src/events/utilities/activity-durability.spec.ts
+++ b/src/events/utilities/activity-durability.spec.ts
@@ -464,6 +464,22 @@ describe('activity durability', () => {
     expect(calculateActivityDurabilitySourceFingerprint(activity)).toBe('durability-v1:e7472eb7e027f402');
   });
 
+  it('preserves protocol-v1 sparse stream fingerprint behavior', () => {
+    const sparsePower = new Array<number | null>(6);
+    sparsePower[1] = 120;
+    sparsePower[4] = 250;
+    const activity = mockActivity({
+      type: ActivityTypes.Cycling,
+      durationSeconds: 6,
+      streams: {
+        [DataPower.type]: sparsePower,
+        [DataHeartRate.type]: []
+      }
+    });
+
+    expect(calculateActivityDurabilitySourceFingerprint(activity)).toBe('durability-v1:2b17188ff73f3967');
+  });
+
   it('reuses current evidence, regenerates stale evidence, and preserves compact summary-only data', () => {
     const start = new Date(0);
     const activity = new Activity(start, new Date(3600 * 1000), ActivityTypes.Cycling, new Creator('Test'));

--- a/src/events/utilities/activity-durability.spec.ts
+++ b/src/events/utilities/activity-durability.spec.ts
@@ -450,6 +450,20 @@ describe('activity durability', () => {
     expect(calculateActivityDurabilitySourceFingerprint(pool)).not.toBe(originalPool);
   });
 
+  it('preserves the protocol-v1 fingerprint for all supported numeric edge values', () => {
+    const activity = mockActivity({
+      type: ActivityTypes.Cycling,
+      durationSeconds: 8,
+      streams: {
+        [DataPower.type]: [null, NaN, Infinity, -Infinity, -0, 0, 123.456789, 200],
+        [DataHeartRate.type]: [100, null, 101.5, 0, -0, NaN, Infinity, -Infinity]
+      },
+      stats: { [DataHeartRateZoneOneDuration.type]: 123 }
+    });
+
+    expect(calculateActivityDurabilitySourceFingerprint(activity)).toBe('durability-v1:e7472eb7e027f402');
+  });
+
   it('reuses current evidence, regenerates stale evidence, and preserves compact summary-only data', () => {
     const start = new Date(0);
     const activity = new Activity(start, new Date(3600 * 1000), ActivityTypes.Cycling, new Creator('Test'));

--- a/src/events/utilities/activity-durability.spec.ts
+++ b/src/events/utilities/activity-durability.spec.ts
@@ -480,6 +480,26 @@ describe('activity durability', () => {
     expect(calculateActivityDurabilitySourceFingerprint(activity)).toBe('durability-v1:2b17188ff73f3967');
   });
 
+  it('preserves protocol-v1 fingerprints across multiple hash batching boundaries', () => {
+    const power = Array.from({ length: 4096 }, (_value, index) => (index % 17 === 0 ? null : index * 0.25));
+    const sparseHeartRate = new Array<number | null>(4096);
+    for (let index = 0; index < sparseHeartRate.length; index++) {
+      if (index % 3 !== 0) {
+        sparseHeartRate[index] = 90 + (index % 120);
+      }
+    }
+    const activity = mockActivity({
+      type: ActivityTypes.Cycling,
+      durationSeconds: 4096,
+      streams: {
+        [DataPower.type]: power,
+        [DataHeartRate.type]: sparseHeartRate
+      }
+    });
+
+    expect(calculateActivityDurabilitySourceFingerprint(activity)).toBe('durability-v1:f7dd61d7aada0dc3');
+  });
+
   it('reuses current evidence, regenerates stale evidence, and preserves compact summary-only data', () => {
     const start = new Date(0);
     const activity = new Activity(start, new Date(3600 * 1000), ActivityTypes.Cycling, new Creator('Test'));

--- a/src/events/utilities/activity-durability.ts
+++ b/src/events/utilities/activity-durability.ts
@@ -187,24 +187,45 @@ class DurabilityFingerprint {
     this.update(`${label.length}:${label}${fingerprintValue(value)}`);
   }
 
+  addStream(type: string, values: (number | null)[]): void {
+    this.add(`${type}-length`, values.length);
+
+    let chunk = '';
+    for (let index = 0; index < values.length; index++) {
+      const indexText = `${index}`;
+      const labelLength = type.length + 1 + indexText.length;
+      chunk += `${labelLength}:${type}-${indexText}${fingerprintValue(values[index])}`;
+
+      if (chunk.length >= 16_384) {
+        this.update(chunk);
+        chunk = '';
+      }
+    }
+    if (chunk.length) {
+      this.update(chunk);
+    }
+  }
+
   digest(): string {
     return `durability-v1:${toHex(this.first)}${toHex(this.second)}`;
   }
 
   private update(value: string): void {
+    let first = this.first;
+    let second = this.second;
     for (let index = 0; index < value.length; index += 1) {
       const code = value.charCodeAt(index);
-      this.first = Math.imul(this.first ^ code, 0x01000193);
-      this.second = Math.imul(this.second ^ code, 0x85ebca6b);
-      this.second ^= this.second >>> 13;
+      first = Math.imul(first ^ code, 0x01000193);
+      second = Math.imul(second ^ code, 0x85ebca6b);
+      second ^= second >>> 13;
     }
+    this.first = first;
+    this.second = second;
   }
 }
 
 function addStreamFingerprint(fingerprint: DurabilityFingerprint, activity: ActivityInterface, type: string): void {
-  const values = safeGetStream(activity, type);
-  fingerprint.add(`${type}-length`, values.length);
-  values.forEach((value, index) => fingerprint.add(`${type}-${index}`, value));
+  fingerprint.addStream(type, safeGetStream(activity, type));
 }
 
 function addStatFingerprints(

--- a/src/events/utilities/activity-durability.ts
+++ b/src/events/utilities/activity-durability.ts
@@ -191,7 +191,11 @@ class DurabilityFingerprint {
     this.add(`${type}-length`, values.length);
 
     let chunk = '';
-    for (let index = 0; index < values.length; index++) {
+    const valuesLength = values.length;
+    for (let index = 0; index < valuesLength; index++) {
+      if (!(index in values)) {
+        continue;
+      }
       const indexText = `${index}`;
       const labelLength = type.length + 1 + indexText.length;
       chunk += `${labelLength}:${type}-${indexText}${fingerprintValue(values[index])}`;
@@ -733,12 +737,7 @@ function buildAerobicEvidence(
   const secondOutput = averageAccumulatorOutput(secondHalf);
   const firstHeartRate = averageAccumulatorHeartRate(firstHalf);
   const secondHeartRate = averageAccumulatorHeartRate(secondHalf);
-  if (
-    firstOutput === null ||
-    secondOutput === null ||
-    firstHeartRate === null ||
-    secondHeartRate === null
-  ) {
+  if (firstOutput === null || secondOutput === null || firstHeartRate === null || secondHeartRate === null) {
     return null;
   }
   // Persist canonical base values first, then calculate every derived value from those
@@ -760,10 +759,7 @@ function buildAerobicEvidence(
     kind: 'aerobic-efficiency',
     firstHalfEfficiency,
     secondHalfEfficiency,
-    decouplingPercent: round(
-      ((firstHalfEfficiency - secondHalfEfficiency) / firstHalfEfficiency) * 100,
-      3
-    ),
+    decouplingPercent: round(((firstHalfEfficiency - secondHalfEfficiency) / firstHalfEfficiency) * 100, 3),
     firstHalfOutput,
     secondHalfOutput,
     outputRetentionPercent: round((secondHalfOutput / firstHalfOutput) * 100, 3),

--- a/src/events/utilities/activity.utilities.spec.ts
+++ b/src/events/utilities/activity.utilities.spec.ts
@@ -141,6 +141,63 @@ describe('Activity Utilities', () => {
     expect(ActivityUtilities.getDataTypeAvg(event.getFirstActivity(), DataAltitude.type)).toBe(300);
   });
 
+  it('should calculate stream aggregates without changing numeric filtering semantics', () => {
+    event.getFirstActivity().addStream(new Stream(DataHeartRate.type, [null, NaN, Infinity, -Infinity, -0, 0, 2, 4]));
+
+    expect(ActivityUtilities.getDataTypeAvg(event.getFirstActivity(), DataHeartRate.type)).toBe(1.5);
+    expect(Object.is(ActivityUtilities.getDataTypeMin(event.getFirstActivity(), DataHeartRate.type), -0)).toBe(true);
+    expect(ActivityUtilities.getDataTypeMax(event.getFirstActivity(), DataHeartRate.type)).toBe(4);
+    expect(
+      ActivityUtilities.getDataTypeAvg(event.getFirstActivity(), DataHeartRate.type, undefined, undefined, 0)
+    ).toBe(3);
+    expect(
+      ActivityUtilities.getDataTypeMin(event.getFirstActivity(), DataHeartRate.type, undefined, undefined, 0)
+    ).toBe(2);
+    expect(ActivityUtilities.getDataTypeFirst(event.getFirstActivity(), DataHeartRate.type)).toBe(Infinity);
+    expect(ActivityUtilities.getDataTypeLast(event.getFirstActivity(), DataHeartRate.type)).toBe(4);
+  });
+
+  it('should preserve empty and date-bounded aggregate results', () => {
+    event.getFirstActivity().addStream(new Stream(DataHeartRate.type, [null, NaN, Infinity, -Infinity]));
+    event.getFirstActivity().addStream(new Stream(DataAltitude.type, [1, 2, 3, 4]));
+
+    expect(ActivityUtilities.getDataTypeAvg(event.getFirstActivity(), DataHeartRate.type)).toBeNaN();
+    expect(ActivityUtilities.getDataTypeMin(event.getFirstActivity(), DataHeartRate.type)).toBe(Infinity);
+    expect(ActivityUtilities.getDataTypeMax(event.getFirstActivity(), DataHeartRate.type)).toBe(-Infinity);
+    expect(
+      ActivityUtilities.getDataTypeAvg(event.getFirstActivity(), DataAltitude.type, new Date(1000), new Date(3000))
+    ).toBe(3);
+    expect(
+      ActivityUtilities.getDataTypeFirst(event.getFirstActivity(), DataAltitude.type, new Date(1000), new Date(3000))
+    ).toBe(2);
+    expect(
+      ActivityUtilities.getDataTypeLast(event.getFirstActivity(), DataAltitude.type, new Date(1000), new Date(3000))
+    ).toBe(4);
+  });
+
+  it('should shape only finite samples and preserve their original indexes', () => {
+    const activity = event.getFirstActivity();
+    activity.addStream(new Stream(DataAltitude.type, [1, null, Infinity, 3, NaN, -Infinity, 5]));
+    activity.addStream(new Stream(DataDistance.type, [0, 1, 2, 3, 4, 5, 6]));
+
+    ActivityUtilities.shapeStream(DataAltitude.type, activity, values => values.map(value => value * 10));
+
+    expect(activity.getStreamData(DataAltitude.type)).toEqual([
+      10,
+      null,
+      null,
+      30,
+      null,
+      null,
+      50,
+      null,
+      null,
+      null,
+      null
+    ]);
+    expect(activity.getAllStreams().map(stream => stream.type)).toEqual([DataDistance.type, DataAltitude.type]);
+  });
+
   it('should get the correct gain for a DataType', () => {
     event.getFirstActivity().addStream(new Stream(DataAltitude.type, [200, 300, 400]));
     expect(ActivityUtilities.getActivityDataTypeGain(event.getFirstActivity(), DataAltitude.type)).toBe(200);

--- a/src/events/utilities/activity.utilities.spec.ts
+++ b/src/events/utilities/activity.utilities.spec.ts
@@ -175,6 +175,47 @@ describe('Activity Utilities', () => {
     ).toBe(4);
   });
 
+  it('should match legacy aggregates for deterministic sparse and non-finite streams', () => {
+    let randomState = 0x5f3759df;
+    const random = () => {
+      randomState = (Math.imul(randomState, 1664525) + 1013904223) >>> 0;
+      return randomState / 0x1_0000_0000;
+    };
+    const specialValues: (number | null)[] = [null, NaN, Infinity, -Infinity, -0, 0, -10, 2.5, 100];
+
+    for (let iteration = 0; iteration < 64; iteration++) {
+      const values = new Array<number | null>(1 + Math.floor(random() * 80));
+      for (let index = 0; index < values.length; index++) {
+        if (random() >= 0.15) {
+          values[index] = specialValues[Math.floor(random() * specialValues.length)];
+        }
+      }
+      const activity = new Activity(new Date(0), new Date(1000), ActivityTypes.Running, new Creator('Test'));
+      activity.addStream(new Stream(DataHeartRate.type, values));
+      const numeric = values.filter(value => typeof value === 'number' && !isNaN(value)) as number[];
+      const finite = numeric.filter(value => value !== Infinity && value !== -Infinity);
+
+      for (const filterOver of [undefined, NaN, -Infinity, -0, 2.5, Infinity]) {
+        const filtered = finite.filter(value => (Number.isFinite(filterOver) ? value > (filterOver as number) : true));
+        const expectedAverage = filtered.reduce((sum, value) => sum + value, 0) / filtered.length;
+        const expectedMinimum = filtered.reduce((minimum, value) => Math.min(minimum, value), Infinity);
+
+        expect(ActivityUtilities.getDataTypeAvg(activity, DataHeartRate.type, undefined, undefined, filterOver)).toBe(
+          expectedAverage
+        );
+        expect(ActivityUtilities.getDataTypeMin(activity, DataHeartRate.type, undefined, undefined, filterOver)).toBe(
+          expectedMinimum
+        );
+      }
+
+      expect(ActivityUtilities.getDataTypeMax(activity, DataHeartRate.type)).toBe(
+        finite.reduce((maximum, value) => Math.max(maximum, value), -Infinity)
+      );
+      expect(ActivityUtilities.getDataTypeFirst(activity, DataHeartRate.type)).toBe(numeric[0]);
+      expect(ActivityUtilities.getDataTypeLast(activity, DataHeartRate.type)).toBe(numeric[numeric.length - 1]);
+    }
+  });
+
   it('should shape only finite samples and preserve their original indexes', () => {
     const activity = event.getFirstActivity();
     activity.addStream(new Stream(DataAltitude.type, [1, null, Infinity, 3, NaN, -Infinity, 5]));
@@ -196,6 +237,15 @@ describe('Activity Utilities', () => {
       null
     ]);
     expect(activity.getAllStreams().map(stream => stream.type)).toEqual([DataDistance.type, DataAltitude.type]);
+  });
+
+  it('should preserve irregular IBI timing when shaping the stream', () => {
+    const activity = new Activity(new Date(0), new Date(3000), ActivityTypes.Running, new Creator('Test'));
+    activity.addStream(new IBIStream([823, 823, 823]));
+
+    ActivityUtilities.shapeStream(DataIBI.type, activity, () => [100, 200, 300]);
+
+    expect(activity.getStreamData(DataIBI.type)).toEqual([null, 100, 300, null]);
   });
 
   it('should get the correct gain for a DataType', () => {

--- a/src/events/utilities/activity.utilities.ts
+++ b/src/events/utilities/activity.utilities.ts
@@ -471,6 +471,22 @@ export class ActivityUtilities {
     endDate?: Date,
     filterOver?: number
   ): number {
+    if (startDate === undefined && endDate === undefined) {
+      const data = activity.getStreamData(streamType);
+      const shouldFilterOver = Number.isFinite(filterOver);
+      let sum = 0;
+      let count = 0;
+
+      for (const value of data) {
+        if (Number.isFinite(value) && (!shouldFilterOver || (value as number) > (filterOver as number))) {
+          sum += value as number;
+          count++;
+        }
+      }
+
+      return sum / count;
+    }
+
     const data = <number[]>(
       activity
         .getSquashedStreamData(streamType, startDate, endDate)
@@ -574,6 +590,16 @@ export class ActivityUtilities {
     startDate?: Date,
     endDate?: Date
   ): number {
+    if (startDate === undefined && endDate === undefined) {
+      const data = activity.getStreamData(streamType);
+      for (const value of data) {
+        if (isNumber(value)) {
+          return value as number;
+        }
+      }
+      return undefined as unknown as number;
+    }
+
     const data = <number[]>activity.getSquashedStreamData(streamType, startDate, endDate);
     return data[0];
   }
@@ -584,6 +610,17 @@ export class ActivityUtilities {
     startDate?: Date,
     endDate?: Date
   ): number {
+    if (startDate === undefined && endDate === undefined) {
+      const data = activity.getStreamData(streamType);
+      for (let index = data.length - 1; index >= 0; index--) {
+        const value = data[index];
+        if (isNumber(value)) {
+          return value as number;
+        }
+      }
+      return undefined as unknown as number;
+    }
+
     const data = <number[]>activity.getSquashedStreamData(streamType, startDate, endDate);
     return data[data.length - 1];
   }
@@ -3236,25 +3273,27 @@ export class ActivityUtilities {
     activity: ActivityInterface,
     shapeStreamData: (squashedStreamData: number[]) => number[]
   ): void {
-    let streamDataByDuration = activity.getStreamDataByDuration(streamType, true, true);
+    const sourceData = activity.getStreamData(streamType);
+    const sourceIndexes: number[] = [];
+    const sourceValues: number[] = [];
 
-    // Shape data along function param
-    const streamData = shapeStreamData(streamDataByDuration.map(item => item.value) as number[]);
+    for (let index = 0; index < sourceData.length; index++) {
+      const value = sourceData[index];
+      if (Number.isFinite(value)) {
+        sourceIndexes.push(index);
+        sourceValues.push(value as number);
+      }
+    }
 
-    // Update streamDataByDuration with shaped data
-    streamDataByDuration = streamDataByDuration.map((item: StreamDataItem, index: number) => {
-      item.value = streamData[index];
-      return item;
-    });
-
-    // Rebuild/replace stream with new shaped value
+    const shapedValues = shapeStreamData(sourceValues);
     activity.removeStream(streamType);
-    activity.addStream(activity.createStream(streamType));
+    const targetStream = activity.createStream(streamType);
+    const targetData = targetStream.getData();
+    activity.addStream(targetStream);
 
-    const activityStartTime = activity.startDate.getTime();
-    streamDataByDuration.forEach(item => {
-      activity.addDataToStream(streamType, new Date(activityStartTime + item.time), item.value as number);
-    });
+    for (let index = 0; index < sourceIndexes.length; index++) {
+      targetData[sourceIndexes[index]] = shapedValues[index];
+    }
   }
 
   public static cloneStream(activity: ActivityInterface, sourceStreamType: string, targetStreamType: string): void {
@@ -3478,6 +3517,20 @@ export class ActivityUtilities {
     endDate?: Date,
     filterOver?: number
   ): number {
+    if (startDate === undefined && endDate === undefined) {
+      const data = activity.getStreamData(streamType);
+      const shouldFilterOver = Number.isFinite(filterOver);
+      let result = max ? -Infinity : Infinity;
+
+      for (const value of data) {
+        if (Number.isFinite(value) && (!shouldFilterOver || (value as number) > (filterOver as number))) {
+          result = max ? Math.max(result, value as number) : Math.min(result, value as number);
+        }
+      }
+
+      return result;
+    }
+
     const data = activity
       .getSquashedStreamData(streamType, startDate, endDate)
       .filter(

--- a/src/events/utilities/activity.utilities.ts
+++ b/src/events/utilities/activity.utilities.ts
@@ -200,6 +200,7 @@ import { DataGroundContactTime } from '../../data/data.ground-contact-time';
 import { DataGroundContactTimeAvg } from '../../data/data.ground-contact-time-avg';
 import { DataGroundContactTimeMax } from '../../data/data.ground-contact-time-max';
 import { DataGroundContactTimeMin } from '../../data/data.ground-contact-time-min';
+import { DataIBI } from '../../data/data.ibi';
 import { DataGroundContactTimeBalanceLeft } from '../../data/data-ground-contact-time-balance-left';
 import { DataGroundContactTimeBalanceRight } from '../../data/data-ground-contact-time-balance-right';
 import {
@@ -3273,6 +3274,21 @@ export class ActivityUtilities {
     activity: ActivityInterface,
     shapeStreamData: (squashedStreamData: number[]) => number[]
   ): void {
+    if (streamType === DataIBI.type) {
+      const sourceItems = activity.getStreamDataByDuration(streamType, true, true);
+      const shapedValues = shapeStreamData(sourceItems.map(item => item.value) as number[]);
+      activity.removeStream(streamType);
+      const targetStream = activity.createStream(streamType);
+      activity.addStream(targetStream);
+      const targetData = targetStream.getData();
+
+      for (let index = 0; index < sourceItems.length; index++) {
+        targetData[activity.getDateIndex(new Date(activity.startDate.getTime() + sourceItems[index].time))] =
+          shapedValues[index];
+      }
+      return;
+    }
+
     const sourceData = activity.getStreamData(streamType);
     const sourceIndexes: number[] = [];
     const sourceValues: number[] = [];
@@ -3288,8 +3304,8 @@ export class ActivityUtilities {
     const shapedValues = shapeStreamData(sourceValues);
     activity.removeStream(streamType);
     const targetStream = activity.createStream(streamType);
-    const targetData = targetStream.getData();
     activity.addStream(targetStream);
+    const targetData = targetStream.getData();
 
     for (let index = 0; index < sourceIndexes.length; index++) {
       targetData[sourceIndexes[index]] = shapedValues[index];

--- a/src/events/utilities/grade-calculator/grade-calculator.regression.spec.ts
+++ b/src/events/utilities/grade-calculator/grade-calculator.regression.spec.ts
@@ -1,0 +1,521 @@
+import { GradeCalculator } from './grade-calculator';
+
+type StreamValue = number | null;
+
+interface GradeStreamCase {
+  name: string;
+  time: StreamValue[];
+  distance: StreamValue[];
+  altitude: StreamValue[];
+  aheadMeters?: number;
+  clamp?: number;
+}
+
+/**
+ * Frozen reference for the pre-optimization grade behavior.
+ *
+ * Keep this implementation intentionally independent from GradeCalculator so an
+ * optimized lookup can be checked against today's handling of sparse, duplicate,
+ * non-monotonic, and non-finite stream data.
+ */
+const legacyComputeGradeStream = (
+  timeStream: StreamValue[],
+  distanceStream: StreamValue[],
+  altitudeStream: StreamValue[],
+  aheadMeters = 10,
+  clamp = 50
+): StreamValue[] => {
+  const squashedAlignedTime: number[] = [];
+  const squashedAlignedDistance: number[] = [];
+  const squashedAlignedAltitude: number[] = [];
+
+  let lastKnownDistance = distanceStream.find(distance => Number.isFinite(distance));
+  let lastKnownAltitude = altitudeStream.find(altitude => Number.isFinite(altitude));
+
+  timeStream.forEach((seconds, index) => {
+    if (!Number.isFinite(seconds)) {
+      return;
+    }
+
+    const distance = distanceStream[index];
+    const altitude = altitudeStream[index];
+    if (Number.isFinite(distance) && Number.isFinite(altitude)) {
+      squashedAlignedTime.push(seconds as number);
+      squashedAlignedDistance.push(distance as number);
+      squashedAlignedAltitude.push(altitude as number);
+      lastKnownDistance = distance;
+      lastKnownAltitude = altitude;
+    } else if (!Number.isFinite(distance) && Number.isFinite(altitude)) {
+      squashedAlignedTime.push(seconds as number);
+      squashedAlignedDistance.push(lastKnownDistance as number);
+      squashedAlignedAltitude.push(altitude as number);
+      lastKnownAltitude = altitude;
+    } else if (Number.isFinite(distance) && !Number.isFinite(altitude)) {
+      squashedAlignedTime.push(seconds as number);
+      squashedAlignedDistance.push(distance as number);
+      squashedAlignedAltitude.push(lastKnownAltitude as number);
+      lastKnownDistance = distance;
+    }
+  });
+
+  const squashedAlignedGrade: number[] = [];
+  let indexNow = 0;
+  do {
+    const aheadDistances = squashedAlignedDistance.slice(indexNow);
+    const aheadAltitudes = squashedAlignedAltitude.slice(indexNow);
+    const distanceNow = aheadDistances[0];
+    const altitudeNow = aheadAltitudes[0];
+
+    let aheadIndex = aheadDistances.findIndex(distance => distanceNow + aheadMeters <= distance);
+    aheadIndex = aheadIndex >= 0 ? aheadIndex : aheadDistances.length - 1;
+
+    const aheadDeltaDistance = aheadDistances[aheadIndex] - distanceNow;
+    const aheadDeltaAltitude = aheadAltitudes[aheadIndex] - altitudeNow;
+    const aheadGrade =
+      aheadDeltaDistance > 0 ? Math.min(Math.max((aheadDeltaAltitude / aheadDeltaDistance) * 100, -clamp), clamp) : 0;
+
+    squashedAlignedGrade.push(Math.round(aheadGrade * 10) / 10);
+    indexNow++;
+  } while (indexNow < squashedAlignedTime.length);
+
+  const gradeStream: StreamValue[] = Array(altitudeStream.length).fill(null);
+  for (const [index, seconds] of squashedAlignedTime.entries()) {
+    gradeStream[seconds] = squashedAlignedGrade[index];
+  }
+  return gradeStream;
+};
+
+const legacyComputeGradeStreamByDistance = (
+  distanceStream: StreamValue[],
+  altitudeStream: StreamValue[],
+  aheadMeters = 10,
+  clamp = 50
+): StreamValue[] => {
+  const points: { index: number; distance: number; altitude: number }[] = [];
+  let lastKnownDistance: number | null = null;
+  let lastKnownAltitude: number | null = null;
+
+  const streamLength = Math.max(distanceStream.length, altitudeStream.length);
+  for (let index = 0; index < streamLength; index++) {
+    const distance = distanceStream[index];
+    const altitude = altitudeStream[index];
+    if (Number.isFinite(distance) && Number.isFinite(altitude)) {
+      points.push({ index, distance: distance as number, altitude: altitude as number });
+      lastKnownDistance = distance;
+      lastKnownAltitude = altitude;
+    } else if (!Number.isFinite(distance) && Number.isFinite(altitude) && Number.isFinite(lastKnownDistance)) {
+      points.push({ index, distance: lastKnownDistance as number, altitude: altitude as number });
+      lastKnownAltitude = altitude;
+    } else if (Number.isFinite(distance) && !Number.isFinite(altitude) && Number.isFinite(lastKnownAltitude)) {
+      points.push({ index, distance: distance as number, altitude: lastKnownAltitude as number });
+      lastKnownDistance = distance;
+    }
+  }
+
+  const gradeStream: StreamValue[] = Array(streamLength).fill(null);
+  if (!points.length) {
+    return gradeStream;
+  }
+
+  const grades: number[] = [];
+  for (let indexNow = 0; indexNow < points.length; indexNow++) {
+    const aheadPoints = points.slice(indexNow);
+    const pointNow = aheadPoints[0];
+    let aheadIndex = aheadPoints.findIndex(point => pointNow.distance + aheadMeters <= point.distance);
+    aheadIndex = aheadIndex >= 0 ? aheadIndex : aheadPoints.length - 1;
+
+    const aheadPoint = aheadPoints[aheadIndex];
+    const aheadDeltaDistance = aheadPoint.distance - pointNow.distance;
+    const aheadDeltaAltitude = aheadPoint.altitude - pointNow.altitude;
+    const aheadGrade =
+      aheadDeltaDistance > 0 ? Math.min(Math.max((aheadDeltaAltitude / aheadDeltaDistance) * 100, -clamp), clamp) : 0;
+    grades.push(Math.round(aheadGrade * 10) / 10);
+  }
+
+  points.forEach((point, index) => {
+    gradeStream[point.index] = grades[index];
+  });
+  return gradeStream;
+};
+
+const namedCases: GradeStreamCase[] = [
+  {
+    name: 'empty streams',
+    time: [],
+    distance: [],
+    altitude: []
+  },
+  {
+    name: 'leading one-sided measurements before fully aligned data',
+    time: [0, 1, 2, 3, 4, 5, 6, 7],
+    distance: [null, null, 5, 9, null, 20, 27, 35],
+    altitude: [100, null, null, 103, 104, null, 108, 110]
+  },
+  {
+    name: 'long stationary plateaus and repeated distances',
+    time: Array.from({ length: 80 }, (_value, index) => index),
+    distance: Array.from({ length: 80 }, (_value, index) => (index < 30 ? 0 : index < 60 ? 25 : 25 + (index - 59) * 2)),
+    altitude: Array.from({ length: 80 }, (_value, index) => 100 + Math.floor(index / 8))
+  },
+  {
+    name: 'distance decreases and resets',
+    time: Array.from({ length: 18 }, (_value, index) => index),
+    distance: [0, 4, 9, 15, 21, 18, 8, 3, 7, 14, 22, 31, 2, 5, 12, 20, 19, 35],
+    altitude: [100, 101, 102, 104, 105, 104, 103, 102, 104, 107, 108, 111, 99, 100, 103, 108, 107, 112]
+  },
+  {
+    name: 'non-monotonic data with multiple qualifying future samples',
+    time: Array.from({ length: 12 }, (_value, index) => index),
+    distance: [0, 100, 5, 20, 15, 11, 50, 7, 17, 12, 22, 60],
+    altitude: [0, 20, 5, 8, 7, 6, 18, 4, 9, 7, 12, 22]
+  },
+  {
+    name: 'duplicate time slots',
+    time: [0, 1, 1, 2, 3, 3, 4, 5, 5, 6],
+    distance: [0, 5, 11, 15, 20, 27, 31, 38, 44, 51],
+    altitude: [10, 11, 12, 11, 13, 14, 13, 15, 17, 16]
+  },
+  {
+    name: 'null and non-finite samples',
+    time: [0, 1, null, 3, 4, Number.NaN, 6, 7, 8, 9, 10],
+    distance: [null, 0, 5, Number.NaN, 12, 18, Number.POSITIVE_INFINITY, 25, null, 39, 48],
+    altitude: [100, null, 102, 103, Number.NEGATIVE_INFINITY, 105, 106, Number.NaN, 108, null, 111]
+  },
+  {
+    name: 'no future sample reaches the look-ahead distance',
+    time: [0, 1, 2, 3, 4, 5],
+    distance: [100, 101, 102, 103, 104, 105],
+    altitude: [20, 21, 20, 22, 21, 23],
+    aheadMeters: 25
+  },
+  {
+    name: 'unequal stream lengths and trailing gaps',
+    time: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+    distance: [0, 3, null, 12, 16, Number.NaN, 28, 35],
+    altitude: [50, null, 52, 54, 53, 55, null, 58, 59, 60, null, 63, 65, 66, 67],
+    clamp: 30
+  },
+  {
+    name: 'floating point values immediately around the look-ahead threshold',
+    time: Array.from({ length: 9 }, (_value, index) => index),
+    distance: [0, 9.999999999, 10, 10.000000001, 19.999999999, 20, 20.000000001, 30, 30.000000001],
+    altitude: [0, 1, 2, 3, 4, 5, 6, 7, 8]
+  },
+  {
+    name: 'zero look-ahead distance',
+    time: [0, 1, 2, 3, 4, 5],
+    distance: [0, 0, 5, 5, 10, 15],
+    altitude: [10, 12, 15, 13, 20, 18],
+    aheadMeters: 0
+  },
+  {
+    name: 'negative look-ahead distance',
+    time: [0, 1, 2, 3, 4, 5],
+    distance: [0, 5, 3, 10, 8, 20],
+    altitude: [10, 12, 11, 16, 15, 18],
+    aheadMeters: -5
+  },
+  {
+    name: 'infinite look-ahead distance',
+    time: [0, 1, 2, 3, 4, 5],
+    distance: [0, 5, 10, 15, 20, 25],
+    altitude: [10, 12, 11, 16, 15, 18],
+    aheadMeters: Number.POSITIVE_INFINITY
+  },
+  {
+    name: 'not-a-number look-ahead distance',
+    time: [0, 1, 2, 3, 4, 5],
+    distance: [0, 5, 10, 15, 20, 25],
+    altitude: [10, 12, 11, 16, 15, 18],
+    aheadMeters: Number.NaN
+  },
+  {
+    name: 'large finite values whose look-ahead threshold overflows',
+    time: [0, 1, 2, 3],
+    distance: [Number.MAX_VALUE / 2, Number.MAX_VALUE * 0.75, Number.MAX_VALUE * 0.9, Number.MAX_VALUE],
+    altitude: [0, 10, 20, 30],
+    aheadMeters: Number.MAX_VALUE
+  },
+  {
+    name: 'zero grade clamp',
+    time: [0, 1, 2, 3, 4],
+    distance: [0, 10, 20, 30, 40],
+    altitude: [0, 5, -5, 10, -10],
+    clamp: 0
+  },
+  {
+    name: 'all measurements invalid',
+    time: [0, 1, 2, 3],
+    distance: [null, Number.NaN, Number.POSITIVE_INFINITY, null],
+    altitude: [Number.NaN, null, Number.NEGATIVE_INFINITY, null]
+  }
+];
+
+const createRandom = (initialSeed: number): (() => number) => {
+  let state = initialSeed >>> 0;
+  return () => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+};
+
+const createRandomCase = (seed: number): GradeStreamCase => {
+  const random = createRandom(seed);
+  const length = 1 + Math.floor(random() * 160);
+  const time: StreamValue[] = [];
+  const distance: StreamValue[] = [];
+  const altitude: StreamValue[] = [];
+  let currentDistance = 0;
+  let currentAltitude = 100;
+
+  for (let index = 0; index < length; index++) {
+    const timeChoice = random();
+    time.push(timeChoice < 0.12 ? null : timeChoice < 0.2 && index > 0 ? (time[index - 1] ?? index) : index);
+
+    const distanceChoice = random();
+    if (distanceChoice < 0.1) {
+      distance.push(null);
+    } else if (distanceChoice < 0.14) {
+      distance.push(Number.NaN);
+    } else if (distanceChoice < 0.17) {
+      distance.push(Number.POSITIVE_INFINITY);
+    } else {
+      if (distanceChoice < 0.34) {
+        // Stationary or duplicate distance.
+      } else if (distanceChoice < 0.43) {
+        currentDistance -= random() * 20;
+      } else if (distanceChoice < 0.48) {
+        currentDistance = random() * 25;
+      } else {
+        currentDistance += random() * 14;
+      }
+      distance.push(Math.round(currentDistance * 100) / 100);
+    }
+
+    const altitudeChoice = random();
+    if (altitudeChoice < 0.1) {
+      altitude.push(null);
+    } else if (altitudeChoice < 0.14) {
+      altitude.push(Number.NaN);
+    } else if (altitudeChoice < 0.17) {
+      altitude.push(Number.NEGATIVE_INFINITY);
+    } else {
+      currentAltitude += random() * 8 - 4;
+      altitude.push(Math.round(currentAltitude * 100) / 100);
+    }
+  }
+
+  return {
+    name: `deterministic corrupt stream seed ${seed}`,
+    time,
+    distance,
+    altitude,
+    aheadMeters: [0, 1, 10, 25][seed % 4],
+    clamp: [10, 30, 50, 100][seed % 4]
+  };
+};
+
+const createMonotonicRandomCase = (seed: number): GradeStreamCase => {
+  const random = createRandom(seed ^ 0x9e3779b9);
+  const length = 1 + Math.floor(random() * 200);
+  const time: StreamValue[] = [];
+  const distance: StreamValue[] = [];
+  const altitude: StreamValue[] = [];
+  let currentDistance = random() * 10;
+  let currentAltitude = 100 + random() * 20;
+
+  for (let index = 0; index < length; index++) {
+    const timeChoice = random();
+    time.push(timeChoice < 0.1 ? null : timeChoice < 0.18 && index > 0 ? (time[index - 1] ?? index) : index);
+
+    const distanceChoice = random();
+    if (distanceChoice < 0.1) {
+      distance.push(null);
+    } else if (distanceChoice < 0.14) {
+      distance.push(Number.NaN);
+    } else {
+      if (distanceChoice >= 0.35) {
+        currentDistance += random() * 15;
+      }
+      distance.push(Math.round(currentDistance * 1000) / 1000);
+    }
+
+    const altitudeChoice = random();
+    if (altitudeChoice < 0.1) {
+      altitude.push(null);
+    } else if (altitudeChoice < 0.14) {
+      altitude.push(Number.NaN);
+    } else {
+      currentAltitude += random() * 6 - 3;
+      altitude.push(Math.round(currentAltitude * 1000) / 1000);
+    }
+  }
+
+  return {
+    name: `deterministic monotonic stream seed ${seed}`,
+    time,
+    distance,
+    altitude,
+    aheadMeters: [0, 0.001, 1, 10, 25][seed % 5],
+    clamp: [0, 10, 30, 50, 100][seed % 5]
+  };
+};
+
+describe('GradeCalculator legacy output preservation', () => {
+  describe.each(namedCases)('$name', testCase => {
+    it('preserves time-indexed grade values and does not mutate inputs', () => {
+      const originalTime = [...testCase.time];
+      const originalDistance = [...testCase.distance];
+      const originalAltitude = [...testCase.altitude];
+
+      expect(
+        GradeCalculator.computeGradeStream(
+          testCase.time,
+          testCase.distance,
+          testCase.altitude,
+          testCase.aheadMeters,
+          testCase.clamp
+        )
+      ).toStrictEqual(
+        legacyComputeGradeStream(
+          testCase.time,
+          testCase.distance,
+          testCase.altitude,
+          testCase.aheadMeters,
+          testCase.clamp
+        )
+      );
+      expect(testCase.time).toStrictEqual(originalTime);
+      expect(testCase.distance).toStrictEqual(originalDistance);
+      expect(testCase.altitude).toStrictEqual(originalAltitude);
+    });
+
+    it('preserves point-indexed grade values and does not mutate inputs', () => {
+      const originalDistance = [...testCase.distance];
+      const originalAltitude = [...testCase.altitude];
+
+      expect(
+        GradeCalculator.computeGradeStreamByDistance(
+          testCase.distance,
+          testCase.altitude,
+          testCase.aheadMeters,
+          testCase.clamp
+        )
+      ).toStrictEqual(
+        legacyComputeGradeStreamByDistance(testCase.distance, testCase.altitude, testCase.aheadMeters, testCase.clamp)
+      );
+      expect(testCase.distance).toStrictEqual(originalDistance);
+      expect(testCase.altitude).toStrictEqual(originalAltitude);
+    });
+  });
+
+  it.each(Array.from({ length: 64 }, (_value, index) => createRandomCase(index + 1)))(
+    'matches the legacy implementation for $name',
+    testCase => {
+      expect(
+        GradeCalculator.computeGradeStream(
+          testCase.time,
+          testCase.distance,
+          testCase.altitude,
+          testCase.aheadMeters,
+          testCase.clamp
+        )
+      ).toStrictEqual(
+        legacyComputeGradeStream(
+          testCase.time,
+          testCase.distance,
+          testCase.altitude,
+          testCase.aheadMeters,
+          testCase.clamp
+        )
+      );
+      expect(
+        GradeCalculator.computeGradeStreamByDistance(
+          testCase.distance,
+          testCase.altitude,
+          testCase.aheadMeters,
+          testCase.clamp
+        )
+      ).toStrictEqual(
+        legacyComputeGradeStreamByDistance(testCase.distance, testCase.altitude, testCase.aheadMeters, testCase.clamp)
+      );
+    }
+  );
+
+  it.each(Array.from({ length: 64 }, (_value, index) => createMonotonicRandomCase(index + 1)))(
+    'matches the legacy implementation for $name',
+    testCase => {
+      expect(
+        GradeCalculator.computeGradeStream(
+          testCase.time,
+          testCase.distance,
+          testCase.altitude,
+          testCase.aheadMeters,
+          testCase.clamp
+        )
+      ).toStrictEqual(
+        legacyComputeGradeStream(
+          testCase.time,
+          testCase.distance,
+          testCase.altitude,
+          testCase.aheadMeters,
+          testCase.clamp
+        )
+      );
+      expect(
+        GradeCalculator.computeGradeStreamByDistance(
+          testCase.distance,
+          testCase.altitude,
+          testCase.aheadMeters,
+          testCase.clamp
+        )
+      ).toStrictEqual(
+        legacyComputeGradeStreamByDistance(testCase.distance, testCase.altitude, testCase.aheadMeters, testCase.clamp)
+      );
+    }
+  );
+});
+
+describe('GradeCalculator large-stream regression guards', () => {
+  it('does not perform per-sample suffix slicing in either grade path', () => {
+    const length = 2048;
+    const time = Array.from({ length }, (_value, index) => index);
+    const distance = Array.from({ length }, (_value, index) => index % 97);
+    const altitude = Array.from({ length }, () => 100);
+    const sliceSpy = jest.spyOn(Array.prototype, 'slice');
+    let sliceCalls = Number.POSITIVE_INFINITY;
+
+    try {
+      GradeCalculator.computeGradeStream(time, distance, altitude);
+      GradeCalculator.computeGradeStreamByDistance(distance, altitude);
+      sliceCalls = sliceSpy.mock.calls.length;
+    } finally {
+      sliceSpy.mockRestore();
+    }
+
+    expect(sliceCalls).toBeLessThan(10);
+  });
+
+  it('preserves every sample in a large monotonic stream', () => {
+    const length = 50_000;
+    const time = Array.from({ length }, (_value, index) => index);
+    const distance = Array.from({ length }, (_value, index) => index * 2);
+    const altitude = Array.from({ length }, (_value, index) => index * 0.2);
+    const expected = Array<number>(length).fill(10);
+    expected[length - 1] = 0;
+
+    expect(GradeCalculator.computeGradeStream(time, distance, altitude)).toStrictEqual(expected);
+    expect(GradeCalculator.computeGradeStreamByDistance(distance, altitude)).toStrictEqual(expected);
+  });
+
+  it('preserves every sample in a large stream with repeated distance resets', () => {
+    const length = 30_000;
+    const time = Array.from({ length }, (_value, index) => index);
+    const distance = Array.from({ length }, (_value, index) => index % 200);
+    const altitude = Array<number>(length).fill(100);
+    const expected = Array<number>(length).fill(0);
+
+    expect(GradeCalculator.computeGradeStream(time, distance, altitude)).toStrictEqual(expected);
+    expect(GradeCalculator.computeGradeStreamByDistance(distance, altitude)).toStrictEqual(expected);
+  });
+});

--- a/src/events/utilities/grade-calculator/grade-calculator.ts
+++ b/src/events/utilities/grade-calculator/grade-calculator.ts
@@ -1,6 +1,112 @@
 export const CLAMP = 50;
 export const LOOK_AHEAD_IN_METERS = 10;
 
+type AheadIndexFinder = (startIndex: number) => number;
+
+const isFiniteNonDecreasing = (values: number[]): boolean => {
+  if (!values.length) {
+    return true;
+  }
+
+  if (!Number.isFinite(values[0])) {
+    return false;
+  }
+
+  for (let index = 1; index < values.length; index++) {
+    if (!Number.isFinite(values[index]) || values[index] < values[index - 1]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * Finds the first finite value at or after a requested index that reaches a threshold.
+ *
+ * A max segment tree keeps this lookup O(log n) for corrupt/non-monotonic distance
+ * streams while preserving Array.findIndex's first-match behavior.
+ */
+class FirstDistanceAtLeastIndex {
+  private readonly length: number;
+  private readonly treeSize: number;
+  private readonly maximums: Array<number | undefined>;
+
+  constructor(values: number[]) {
+    this.length = values.length;
+    this.treeSize = this.getTreeSize(values.length);
+    this.maximums = Array(this.treeSize * 2).fill(undefined);
+
+    values.forEach((value, index) => {
+      if (Number.isFinite(value)) {
+        this.maximums[this.treeSize + index] = value;
+      }
+    });
+
+    for (let node = this.treeSize - 1; node > 0; node--) {
+      const left = this.maximums[node * 2];
+      const right = this.maximums[node * 2 + 1];
+      this.maximums[node] = left === undefined ? right : right === undefined ? left : Math.max(left, right);
+    }
+  }
+
+  public findFirst(startIndex: number, threshold: number): number {
+    return this.findFirstInNode(1, 0, this.treeSize, startIndex, threshold);
+  }
+
+  private getTreeSize(length: number): number {
+    let size = 1;
+    while (size < length) {
+      size *= 2;
+    }
+    return size;
+  }
+
+  private findFirstInNode(
+    node: number,
+    leftIndex: number,
+    rightIndex: number,
+    startIndex: number,
+    threshold: number
+  ): number {
+    const maximum = this.maximums[node];
+    if (rightIndex <= startIndex || maximum === undefined || !(threshold <= maximum)) {
+      return -1;
+    }
+
+    if (rightIndex - leftIndex === 1) {
+      return leftIndex < this.length ? leftIndex : -1;
+    }
+
+    const middleIndex = (leftIndex + rightIndex) >> 1;
+    const leftResult = this.findFirstInNode(node * 2, leftIndex, middleIndex, startIndex, threshold);
+    return leftResult >= 0
+      ? leftResult
+      : this.findFirstInNode(node * 2 + 1, middleIndex, rightIndex, startIndex, threshold);
+  }
+}
+
+const createAheadIndexFinder = (distances: number[], aheadMeters: number): AheadIndexFinder => {
+  const lastIndex = distances.length - 1;
+
+  if (isFiniteNonDecreasing(distances)) {
+    let aheadIndex = 0;
+    return (startIndex: number): number => {
+      aheadIndex = Math.max(aheadIndex, startIndex);
+      const threshold = distances[startIndex] + aheadMeters;
+      while (aheadIndex < distances.length && !(threshold <= distances[aheadIndex])) {
+        aheadIndex++;
+      }
+      return aheadIndex < distances.length ? aheadIndex : lastIndex;
+    };
+  }
+
+  const distanceIndex = new FirstDistanceAtLeastIndex(distances);
+  return (startIndex: number): number => {
+    const matchIndex = distanceIndex.findFirst(startIndex, distances[startIndex] + aheadMeters);
+    return matchIndex >= 0 ? matchIndex : lastIndex;
+  };
+};
+
 export class GradeCalculator {
   public static computeGradeStream(
     timeStream: (number | null)[],
@@ -16,33 +122,21 @@ export class GradeCalculator {
     );
 
     const squashedAlignedGrade = [];
-    let indexNow = 0;
-    do {
-      // Remove first index of distances & altitudes stream at every loop
-      const aheadDistances = squashedAlignedDist.slice(indexNow);
-      const aheadAltitudes = squashedAlignedAlt.slice(indexNow);
-
-      // Take our current distance travelled & altitude
-      const distanceNow = aheadDistances[0];
-      const altitudeNow = aheadAltitudes[0];
-
-      // Find ahead index matching minimal distance travelled
-      let aheadIndex = aheadDistances.findIndex(dist => distanceNow + aheadMeters <= dist);
-
-      // Validate we find an index with distance ahead for sure, else use last index of ahead distances
-      aheadIndex = aheadIndex >= 0 ? aheadIndex : aheadDistances.length - 1;
+    const findAheadIndex = createAheadIndexFinder(squashedAlignedDist, aheadMeters);
+    for (let indexNow = 0; indexNow < squashedAlignedTime.length; indexNow++) {
+      const distanceNow = squashedAlignedDist[indexNow];
+      const altitudeNow = squashedAlignedAlt[indexNow];
+      const aheadIndex = findAheadIndex(indexNow);
 
       // Compute deltas & grade
-      const aheadDeltaDistance = aheadDistances[aheadIndex] - distanceNow;
-      const aheadDeltaAltitude = aheadAltitudes[aheadIndex] - altitudeNow;
+      const aheadDeltaDistance = squashedAlignedDist[aheadIndex] - distanceNow;
+      const aheadDeltaAltitude = squashedAlignedAlt[aheadIndex] - altitudeNow;
 
       const aheadGrade =
         aheadDeltaDistance > 0 ? Math.min(Math.max((aheadDeltaAltitude / aheadDeltaDistance) * 100, -clamp), clamp) : 0;
 
       squashedAlignedGrade.push(Math.round(aheadGrade * 10) / 10);
-
-      indexNow++;
-    } while (indexNow < squashedAlignedTime.length);
+    }
 
     // Rebuild grade stream with empty values using computed squashed/aligned time & grade streams
     const gradeStream = Array(altitudeStream.length).fill(null);
@@ -66,15 +160,13 @@ export class GradeCalculator {
     }
 
     const squashedAlignedGrade = [];
-    let indexNow = 0;
-    do {
-      const aheadPoints = squashedAlignedPoints.slice(indexNow);
-      const pointNow = aheadPoints[0];
-
-      let aheadIndex = aheadPoints.findIndex(point => pointNow.distance + aheadMeters <= point.distance);
-      aheadIndex = aheadIndex >= 0 ? aheadIndex : aheadPoints.length - 1;
-
-      const aheadPoint = aheadPoints[aheadIndex];
+    const findAheadIndex = createAheadIndexFinder(
+      squashedAlignedPoints.map(point => point.distance),
+      aheadMeters
+    );
+    for (let indexNow = 0; indexNow < squashedAlignedPoints.length; indexNow++) {
+      const pointNow = squashedAlignedPoints[indexNow];
+      const aheadPoint = squashedAlignedPoints[findAheadIndex(indexNow)];
       const aheadDeltaDistance = aheadPoint.distance - pointNow.distance;
       const aheadDeltaAltitude = aheadPoint.altitude - pointNow.altitude;
 
@@ -82,9 +174,7 @@ export class GradeCalculator {
         aheadDeltaDistance > 0 ? Math.min(Math.max((aheadDeltaAltitude / aheadDeltaDistance) * 100, -clamp), clamp) : 0;
 
       squashedAlignedGrade.push(Math.round(aheadGrade * 10) / 10);
-
-      indexNow++;
-    } while (indexNow < squashedAlignedPoints.length);
+    }
 
     for (const [index, point] of squashedAlignedPoints.entries()) {
       gradeStream[point.index] = squashedAlignedGrade[index];

--- a/src/geodesy/adapters/geolib.adapter.spec.ts
+++ b/src/geodesy/adapters/geolib.adapter.spec.ts
@@ -20,7 +20,7 @@ describe('GeoLibAdapter', () => {
     }));
     const adapter = new GeoLibAdapter();
 
-    for (const accuracy of [0.1, 1, 10]) {
+    for (const accuracy of [Number.NaN, 0, -0, -1, Number.MIN_VALUE, 0.1, 1, 10, Infinity, -Infinity]) {
       let expected = 0;
       for (let index = 1; index < positions.length; index++) {
         expected += getDistance(asGeolibPosition(positions[index - 1]), asGeolibPosition(positions[index]), accuracy);

--- a/src/geodesy/adapters/geolib.adapter.spec.ts
+++ b/src/geodesy/adapters/geolib.adapter.spec.ts
@@ -1,0 +1,53 @@
+import { getDistance, getPreciseDistance } from 'geolib';
+import { DataPositionInterface } from '../../data/data.position.interface';
+import { GeoLibAdapter } from './geolib.adapter';
+
+const asGeolibPosition = (position: DataPositionInterface) => ({
+  latitude: position.latitudeDegrees,
+  longitude: position.longitudeDegrees
+});
+
+describe('GeoLibAdapter', () => {
+  it('matches geolib exactly for long paths and supported accuracies', () => {
+    let state = 0x12345678;
+    const random = () => {
+      state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+      return state / 0x1_0000_0000;
+    };
+    const positions = Array.from({ length: 2000 }, () => ({
+      latitudeDegrees: random() * 170 - 85,
+      longitudeDegrees: random() * 360 - 180
+    }));
+    const adapter = new GeoLibAdapter();
+
+    for (const accuracy of [0.1, 1, 10]) {
+      let expected = 0;
+      for (let index = 1; index < positions.length; index++) {
+        expected += getDistance(asGeolibPosition(positions[index - 1]), asGeolibPosition(positions[index]), accuracy);
+      }
+
+      expect(adapter.getDistance(positions, false, accuracy)).toBe(expected);
+    }
+  });
+
+  it('preserves repeated, near-antipodal, and precise distance behavior', () => {
+    const positions = [
+      { latitudeDegrees: 0, longitudeDegrees: 0 },
+      { latitudeDegrees: 0, longitudeDegrees: 0 },
+      { latitudeDegrees: 0.000001, longitudeDegrees: -0.000001 },
+      { latitudeDegrees: 0, longitudeDegrees: 179.999999 }
+    ];
+    const adapter = new GeoLibAdapter();
+    let expectedPrecise = 0;
+
+    for (let index = 1; index < positions.length; index++) {
+      expectedPrecise += getPreciseDistance(
+        asGeolibPosition(positions[index - 1]),
+        asGeolibPosition(positions[index]),
+        0.1
+      );
+    }
+
+    expect(adapter.getDistance(positions, true, 0.1)).toBe(expectedPrecise);
+  });
+});

--- a/src/geodesy/adapters/geolib.adapter.ts
+++ b/src/geodesy/adapters/geolib.adapter.ts
@@ -1,6 +1,8 @@
 import { GeoLibAdapterInterface } from './adapter.interface';
-import { getPreciseDistance, getDistance, findNearest } from 'geolib';
+import { getPreciseDistance, findNearest } from 'geolib';
 import { DataPositionInterface } from '../../data/data.position.interface';
+
+const EARTH_RADIUS_METERS = 6378137;
 
 export class GeoLibAdapter implements GeoLibAdapterInterface {
   findNearest = findNearest;
@@ -9,22 +11,44 @@ export class GeoLibAdapter implements GeoLibAdapterInterface {
 
   getDistance(positionArray: DataPositionInterface[], precise = false, accuracy = 0.1): number {
     let distance = 0;
-    const excludeFirstPointsArray = positionArray.slice(1);
     let firstPosition = positionArray[0];
-    for (const nextPosition of excludeFirstPointsArray) {
-      const firstPositionAsDecimal = {
-        longitude: firstPosition.longitudeDegrees,
-        latitude: firstPosition.latitudeDegrees
-      };
-      const nextPositionAsDecimal = {
-        longitude: nextPosition.longitudeDegrees,
-        latitude: nextPosition.latitudeDegrees
-      };
-      distance += precise
-        ? getPreciseDistance(firstPositionAsDecimal, nextPositionAsDecimal, accuracy)
-        : getDistance(firstPositionAsDecimal, nextPositionAsDecimal, accuracy);
+    for (let index = 1; index < positionArray.length; index++) {
+      const nextPosition = positionArray[index];
+      if (precise) {
+        distance += getPreciseDistance(
+          {
+            longitude: firstPosition.longitudeDegrees,
+            latitude: firstPosition.latitudeDegrees
+          },
+          {
+            longitude: nextPosition.longitudeDegrees,
+            latitude: nextPosition.latitudeDegrees
+          },
+          accuracy
+        );
+      } else {
+        distance += this.getFastDistance(firstPosition, nextPosition, accuracy);
+      }
       firstPosition = nextPosition;
     }
     return distance;
+  }
+
+  private getFastDistance(
+    firstPosition: DataPositionInterface,
+    nextPosition: DataPositionInterface,
+    accuracy: number
+  ): number {
+    const normalizedAccuracy = typeof accuracy !== 'undefined' && !isNaN(accuracy) ? accuracy : 1;
+    const fromLatitudeRadians = (Number(firstPosition.latitudeDegrees) * Math.PI) / 180;
+    const fromLongitudeRadians = (Number(firstPosition.longitudeDegrees) * Math.PI) / 180;
+    const toLatitudeRadians = (Number(nextPosition.latitudeDegrees) * Math.PI) / 180;
+    const toLongitudeRadians = (Number(nextPosition.longitudeDegrees) * Math.PI) / 180;
+    const cosine =
+      Math.sin(toLatitudeRadians) * Math.sin(fromLatitudeRadians) +
+      Math.cos(toLatitudeRadians) * Math.cos(fromLatitudeRadians) * Math.cos(fromLongitudeRadians - toLongitudeRadians);
+    const robustCosine = cosine > 1 ? 1 : cosine < -1 ? -1 : cosine;
+    const distance = Math.acos(robustCosine) * EARTH_RADIUS_METERS;
+    return Math.round(distance / normalizedAccuracy) * normalizedAccuracy;
   }
 }


### PR DESCRIPTION
## Summary

Make dense 72h+ FIT activities parse reliably within normal application budgets while preserving the exact serialized sports-lib result.

Released decoder dependency: [fit-file-parser 4.0.0](https://github.com/jimmykane/fit-parser/releases/tag/v4.0.0) ([implementation PR #51](https://github.com/jimmykane/fit-parser/pull/51)).

The final end-to-end measurements below use the sports-lib optimization together with fit-file-parser 4.0.0. The grade fix in this PR independently removes the catastrophic path; the released decoder removes the remaining per-field allocation overhead.

## Root cause

Grade generation performed `slice(index).findIndex(...)` for every aligned sample. On 330k–396k dense records, this repeatedly copied and rescanned the remaining stream, making the path quadratic and causing heavy garbage collection and peak memory pressure.

The look-ahead pattern first appeared in commit `67b053af6cf807ffa9bbc4d08bd9be644b8273dc` (`chore: add look ahead`), first released in `4.2.3`. The later grade rewrite in `78352f31` retained the same algorithmic issue.

There is no meaningful 17.1.2 → 17.8.0 regression on these fixtures: both versions take roughly two to three minutes. The observed downstream timeout was most likely a runtime-budget/environment difference.

Secondary profiles showed avoidable linear allocations in FIT sample mapping, time-stream generation, aggregate statistics, stream shaping, durability fingerprinting, and generic geodesy conversion.

## Changes

- Replace quadratic grade suffix scans with:
  - an O(n) monotonic two-pointer path for normal distance streams
  - an O(log n) first-match segment-tree fallback for corrupt/non-monotonic streams
- Construct FIT sample streams with one mapper call per sample and lazy timestamp-index caching.
- Scan regular time streams directly while retaining irregular IBI projection.
- Compute unbounded averages/min/max/first/last without temporary full-stream arrays.
- Shape regular streams using finite indexes/values directly while preserving irregular IBI timing.
- Batch durability fingerprint text and hash with local accumulators while preserving protocol-v1 bytes, including sparse-array behavior.
- Use the exact geolib spherical formula directly for numeric sports-lib positions, avoiding transient coordinate objects and generic key parsing.
- Upgrade the runtime dependency to published `fit-file-parser@^4.0.0`.
- Preserve mapping order, duplicate timestamp last-write behavior, infinities, signed zero, sparse arrays, corrupt streams, and malformed input fallbacks.

## Performance

Three isolated runs per final fixture; table reports median parse wall time. Peak RSS is the median isolated-process peak where available.

| Version | Suunto 93h / 7.5MB | Garmin 110h / 28.6MB |
|---|---:|---:|
| sports-lib 17.1.2 | 124.58s / 931MiB | 187.15s / not captured |
| sports-lib 17.8.0 | 130.14s | 187.36s |
| Grade optimization with fit-file-parser 3.1.3 | 4.14s / 637MiB | 8.36s / 1,113MiB |
| This PR + fit-file-parser 4.0.0 | **1.94s / 567MiB** | **3.30s / 773MiB** |

Compared with sports-lib 17.8.0, the combined result is approximately:

- **67x faster** for Suunto (98.5% lower wall time)
- **57x faster** for Garmin (98.2% lower wall time)

Compared with the grade-only optimization, fit-file-parser 4.0.0 makes Suunto another 53% faster and Garmin another 60% faster, while lowering Garmin peak RSS by about 30%.

A post-publication check using the actual npm tarball completed in 2.02s for Suunto and 3.24s for Garmin in single isolated runs, consistent with the recorded medians.

Both fixtures are comfortably inside the target budget of 4 CPU, 8GiB memory, and 15 minutes.

## Output preservation

Full serialized event JSON remains byte-for-byte unchanged with the published dependency:

- Suunto: 115,042,810 bytes — `297cbcf38d4d7a0235fb65a0c5751633f58dcae772c244625f7ad4ba1b7ce2ef`
- Garmin: 110,453,049 bytes — `cfa05aad802963214071dae08baa54684543b18f1cc3afe4a04065ffc2673ce3`

The fixtures contain ordered, unique record timestamps; duplicate/corrupt records and developer fields are not the cause. Garmin has no developer-field descriptions, while Suunto has four.

## Validation

- `npm ci` resolves the published `fit-file-parser@4.0.0` registry tarball and recorded integrity.
- Full sports-lib suite: 99 suites passed, 1,739 tests passed, 5 skipped.
- Focused final suite: 130 tests passed.
- Build passed for ESM/CJS/declarations.
- Published-package checks reproduced both private fixture output sizes and SHA-256 hashes exactly.
- Scoped ESLint: zero errors.
- 162 checked-in parser fixture/mode comparisons: zero mismatches.
- 8,320 malformed endian-definition comparisons in fit-file-parser: zero mismatches.
- Deterministic randomized parity tests cover sparse/non-finite aggregates, monotonic and corrupt grade streams, geodesy edge accuracies, durability fingerprints, duplicate timestamps, and irregular IBI shaping.

The two private benchmark FIT files remain under ignored `tmp/` storage and are not included in this PR.
