### PR TITLE
feat: expose lap intensity from FIT lap.intensity field

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ remain available for compatibility but are intentionally outside this reference.
 
 FIT imports normalize record-level depth samples to canonical meters and retain session maximum depth. Depth and
 maximum-depth display variants follow the first swim-pace preference, using meters for `/100m` and feet for `/100yd`.
+FIT session and lap intensity enums are retained as the string-valued `Intensity` stat.
 
 ## Start here
 

--- a/docs/api.ts
+++ b/docs/api.ts
@@ -121,6 +121,7 @@ export {
   DataEvent,
   DataEnergy,
   DataHeartRate,
+  DataIntensity,
   DataMovingTime,
   DataPause,
   DataPower,

--- a/docs/guides/importing-activities.md
+++ b/docs/guides/importing-activities.md
@@ -45,6 +45,9 @@ FIT record-level `depth` values are normalized from the profile's millimeter sca
 meters. FIT session `max_depth` and Suunto depth values remain canonical meters. Depth is available as an advanced chart
 metric; callers can request `Depth` explicitly through `ActivityParsingOptions.streams.includeTypes`.
 
+FIT session and lap `intensity` enums are retained as the string-valued `Intensity` stat. Values follow the FIT profile,
+such as `active`, `rest`, `warmup`, `cooldown`, `recovery`, `interval`, and `other`.
+
 Use `importFromSuunto(suuntoJson)` for Suunto JSON. Use `importFromJSON(eventJson)` only for Sports Lib's native `EventJSONInterface` representation.
 
 Native JSON hydration preserves explicit stats and fills missing pace, swim-pace, and grade-adjusted-pace summaries

--- a/docs/guides/metrics-and-calculations.md
+++ b/docs/guides/metrics-and-calculations.md
@@ -445,6 +445,7 @@ Generated from modules re-exported by `src/data/index.ts`, then resolved to each
 - `Heart Rate Used`
 - `Height` (unit: `m`)
 - `IBI` (unit: `ms`)
+- `Intensity`
 - `Impact Loading Rate Balance Left`
 - `Impact Loading Rate Balance Right`
 - `Jump Count`

--- a/src/data/data.intensity.ts
+++ b/src/data/data.intensity.ts
@@ -1,0 +1,5 @@
+import { DataString } from './data.string';
+
+export class DataIntensity extends DataString {
+  static type = 'Intensity';
+}

--- a/src/data/data.intensity.ts
+++ b/src/data/data.intensity.ts
@@ -1,5 +1,8 @@
 import { DataString } from './data.string';
 
+/**
+ * FIT-defined classification of a session's or lap's role, such as warmup, active, or cooldown.
+ */
 export class DataIntensity extends DataString {
   static type = 'Intensity';
 }

--- a/src/data/data.serialization.spec.ts
+++ b/src/data/data.serialization.spec.ts
@@ -23,6 +23,7 @@ import { DataAltiBaroProfile } from './data.alti-baro-profile';
 import { DataActivityTypes } from './data.activity-types';
 import { DataDeviceNames } from './data.device-names';
 import { DataDescription } from './data.description';
+import { DataIntensity } from './data.intensity';
 import { DataPosition } from './data.position';
 import { DataActiveLap } from './data-active-lap';
 import { DataBalance } from './data.balance';
@@ -109,6 +110,7 @@ describe('Data Serialization Safety', () => {
     [DataActivityTypes, [['Running', 'Cycling']]],
     [DataDeviceNames, [['Garmin', 'Suunto']]],
     [DataDescription, ['Test Description']],
+    [DataIntensity, ['active']],
     [DataPosition, [{ latitudeDegrees: 0, longitudeDegrees: 0 }]],
     [DataActiveLap, [true]],
     [DataBalance, [50]],

--- a/src/data/data.store.ts
+++ b/src/data/data.store.ts
@@ -164,6 +164,7 @@ import { DataHeartRateUsed } from './data.heart-rate-used';
 import { DataPowerPodUsed } from './data.power-pod-used';
 import { DataAltiBaroProfile } from './data.alti-baro-profile';
 import { DataIBI } from './data.ibi';
+import { DataIntensity } from './data.intensity';
 import { DataSteps } from './data.steps';
 import { DataPoolLength } from './data.pool-length';
 import { DataSwimDistance } from './data.swim-distance';
@@ -687,6 +688,7 @@ export const DataStore: any = {
   DataVerticalSpeedMinKilometerPerHour,
   DataVerticalSpeedMinMilesPerHour,
   DataIBI,
+  DataIntensity,
   DataSteps,
   DataStepsOld, // @todo find way to make this easy to migrate for projects that persist data based on types
   DataStrydAltitude,

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -135,6 +135,7 @@ export * from './data.heart-rate-zone-two-duration';
 export * from './data.heart-rate';
 export * from './data.height';
 export * from './data.ibi';
+export * from './data.intensity';
 export * from './data.interface';
 export * from './data.json.interface';
 export * from './data.jump-count';

--- a/src/events/adapters/importers/fit/importer.fit.ts
+++ b/src/events/adapters/importers/fit/importer.fit.ts
@@ -13,6 +13,7 @@ import { LapInterface } from '../../../../laps/lap.interface';
 import { DataDistance } from '../../../../data/data.distance';
 import { GarminSports, GarminSubSports } from '../../../../fit/garmin-profile.data';
 import { DataPause } from '../../../../data/data.pause';
+import { DataIntensity } from '../../../../data/data.intensity';
 import { DataInterface } from '../../../../data/data.interface';
 import { DataCadence } from '../../../../data/data.cadence';
 import { DataCadenceAvg } from '../../../../data/data.cadence-avg';
@@ -2254,6 +2255,10 @@ export class EventImporterFIT {
 
     if (Number.isFinite(object.intensity_factor)) {
       stats.push(new DataPowerIntensityFactor(object.intensity_factor));
+    }
+
+    if (isNumberOrString(object.intensity)) {
+      stats.push(new DataIntensity(object.intensity));
     }
 
     if (Number.isFinite(object.training_stress_score)) {


### PR DESCRIPTION
FIT lap messages carry an `intensity` enum (active, rest, warmup, cooldown, recovery, interval, other) classifying the lap's role in the session. This wasn't surfaced as a stat, so consumers had no way to distinguish e.g. warmup/cooldown laps from the main set.

- Add `DataIntensity` (string-valued stat, same shape as `DataDescription`)
- Push it from `EventImporterFIT.getStatsFromObject` whenever a FIT lap/session object has an `intensity` field, alongside the existing `DataPowerIntensityFactor` handling
- Register it in the data barrel export and in `DataStore` so it satisfies the repo's export-completeness (`data.store.export.spec.ts`) and JSON round-trip safety checks (`data.serialization.spec.ts`)

#### Tests
- Full suite: 100/100 suites, 1760/1760 tests passing (5 pre-existing skips, unrelated)
- `npm run build` succeeds
- `npm run lint` on touched files: no new errors/warnings introduced