### PR TITLE
fix: hydrate diving terrain summary semantics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 
 Sports Lib normalizes GPX, TCX, FIT, and service-specific JSON into shared activity and route models. Activity imports
 and native JSON hydration consistently fill missing speed-derived pace summaries on events, activities, and laps while
-preserving applicable explicit values. Supported activity aliases are normalized to canonical types, including Diving-group
-Snorkeling and Mermaiding. The API reference documents the supported consumer API; implementation adapters and parsers
-remain available for compatibility but are intentionally outside this reference.
+preserving applicable explicit values except Diving-group terrain summaries. Supported activity aliases are normalized to
+canonical types, including Diving-group Snorkeling and Mermaiding. The API reference documents the supported consumer
+API; implementation adapters and parsers remain available for compatibility but are intentionally outside this reference.
 
 Activity-aware cadence semantics produce stroke rate for swimming, rowing, and paddle sports. Consumers that store event
 summaries separately from activities can explicitly canonicalize those projections with
@@ -18,8 +18,9 @@ meters and meters per second for `/100m` or feet and feet per second for `/100yd
 places, rates to three, SAC/RMV values to two, and PO₂ retains both FIT decimal places.
 Garmin single-gas, multi-gas, and gauge sub-sports import as `Scuba Diving`; apnea sub-sports import as `Free Diving`.
 FIT session and lap intensity enums are retained as the string-valued `Intensity` stat. Diving-group activities do not
-retain or derive terrain ascent, descent, altitude min/max/avg, or grade min/max/avg summaries. Their vertical movement
-is represented by depth; raw altitude and grade streams remain available when provided by the source.
+retain or derive terrain ascent, descent, altitude min/max/avg, or grade min/max/avg summaries, including when older
+native JSON is restored. Their vertical movement is represented by depth; raw altitude and grade streams remain
+available when provided by the source.
 
 ## Start here
 

--- a/docs/api.ts
+++ b/docs/api.ts
@@ -8,8 +8,9 @@
  */
 
 /**
- * Primary import/export facade. Native JSON restoration preserves applicable explicit stats and adds
- * missing speed-derived pace summaries on events, activities, and laps.
+ * Primary import/export facade. Native JSON restoration preserves applicable explicit stats except
+ * Diving-group terrain summaries, and adds missing speed-derived pace summaries on events,
+ * activities, and laps.
  *
  * @category Import and export
  */
@@ -36,6 +37,12 @@ export type {
 /** @category Activities and events */
 export type { ActivityInterface } from '../src/activities/activity.interface';
 export type { ActivityJSONInterface } from '../src/activities/activity.json.interface';
+/**
+ * Canonicalizes unambiguous activity-summary semantics: cadence-shaped stroke-rate summaries
+ * become `Stroke Rate`, and homogeneous Diving-group summaries omit terrain metrics.
+ *
+ * @category Activities and events
+ */
 export { normalizeActivityMetricSemanticsForStats } from '../src/activities/activity.metric-semantics';
 /**
  * Canonical activity types, activity groups, and alias resolution. Snorkeling and Mermaiding

--- a/docs/guides/exporting.md
+++ b/docs/guides/exporting.md
@@ -28,6 +28,10 @@ for the Diving activity group, canonicalizes compatible legacy keys, may add mis
 events, activities, and laps, and applies activity-aware cadence-to-stroke-rate normalization without requiring the
 original source file.
 
+Starting with 20.0.2, restoring older Diving-group JSON also removes terrain ascent/descent, altitude min/max/avg,
+and grade min/max/avg summaries from events, activities, and laps. The restored model needs no source-file reparse;
+re-serializing it intentionally writes the corrected summary set while retaining any raw source streams.
+
 ```ts
 import { EventExporterJSON, SportsLib } from '@sports-alliance/sports-lib';
 

--- a/docs/guides/importing-activities.md
+++ b/docs/guides/importing-activities.md
@@ -79,11 +79,12 @@ require reparsing from FIT, TCX, or GPX. Pool-swim length JSON keeps its existin
 hydrating that value as `DataStrokeRate`.
 
 Complete native event JSON contains the activities that determine event-summary semantics. Summary-only native event
-JSON receives the same treatment when its `Activity Types` stat is present. When an application persists neither, it
-can opt in after hydration by calling `normalizeActivityMetricSemanticsForStats(summary, contributingActivityTypes)`.
-The helper changes only unambiguous homogeneous stroke-rate summaries and removes terrain summaries from homogeneous
-Diving-group summaries; empty, unknown, and mixed activity-type inputs remain unchanged. Sports Lib does not infer
-relationships omitted by an application-specific persistence layout.
+JSON removes Diving-group terrain summaries when its `Activity Types` stat is present, but preserves other summary
+semantics. An application can opt in after hydration by calling
+`normalizeActivityMetricSemanticsForStats(summary, contributingActivityTypes)`. The helper changes only unambiguous
+homogeneous stroke-rate summaries and removes terrain summaries from homogeneous Diving-group summaries; empty,
+unknown, and mixed activity-type inputs remain unchanged. Sports Lib does not infer relationships omitted by an
+application-specific persistence layout.
 
 ### 20.0.2 native-JSON migration
 

--- a/docs/guides/importing-activities.md
+++ b/docs/guides/importing-activities.md
@@ -57,8 +57,8 @@ Garmin `single_gas_diving`, `multi_gas_diving`, and `gauge_diving` sub-sports re
 Diving activity group.
 
 Diving activities exclude terrain summaries—`Ascent`, `Descent`, altitude min/max/avg, and grade min/max/avg—whether
-they were imported from a FIT summary or would otherwise be hydrated from streams. Depth represents dive vertical
-movement. Any source altitude or grade stream remains available when explicitly requested.
+they were imported from a FIT summary, restored from native JSON, or would otherwise be hydrated from streams. Depth
+represents dive vertical movement. Any source altitude or grade stream remains available when explicitly requested.
 
 FIT session and lap `intensity` enums are retained as the string-valued `Intensity` stat. Values follow the FIT profile,
 such as `active`, `rest`, `warmup`, `cooldown`, `recovery`, `interval`, and `other`.
@@ -78,11 +78,18 @@ It also converts cadence-shaped data to stroke rate for the supported activity t
 require reparsing from FIT, TCX, or GPX. Pool-swim length JSON keeps its existing `avgCadence` property name while
 hydrating that value as `DataStrokeRate`.
 
-Complete native event JSON contains the activities that determine event-summary semantics. Applications that persist
-summary-only projections separately from their activities should opt in after hydration by calling
-`normalizeActivityMetricSemanticsForStats(summary, contributingActivityTypes)`. The helper changes only unambiguous
-homogeneous stroke-rate summaries; empty, unknown, and mixed activity-type inputs remain unchanged. Sports Lib does not
-infer relationships omitted by an application-specific persistence layout.
+Complete native event JSON contains the activities that determine event-summary semantics. Summary-only native event
+JSON receives the same treatment when its `Activity Types` stat is present. When an application persists neither, it
+can opt in after hydration by calling `normalizeActivityMetricSemanticsForStats(summary, contributingActivityTypes)`.
+The helper changes only unambiguous homogeneous stroke-rate summaries and removes terrain summaries from homogeneous
+Diving-group summaries; empty, unknown, and mixed activity-type inputs remain unchanged. Sports Lib does not infer
+relationships omitted by an application-specific persistence layout.
+
+### 20.0.2 native-JSON migration
+
+Restoring existing Diving-group native JSON now removes terrain ascent/descent, altitude min/max/avg, and grade
+min/max/avg summary values from events, activities, and laps. No source-file reparse is needed for the restored
+in-memory model. Re-serializing that model intentionally omits those values; raw source streams remain untouched.
 
 Activities expose one-second streams and typed stats. Read numeric values with `getValue()` and display-ready values with
 `getDisplayValue()`. Depth presentation follows the first swim-pace preference: `/100m` selects meters and `/100yd`

--- a/docs/guides/metrics-and-calculations.md
+++ b/docs/guides/metrics-and-calculations.md
@@ -160,8 +160,8 @@ Cadence and stroke-rate semantics are activity-aware:
   therefore does not need source-file reparsing; serializing the hydrated model writes the canonical stroke-rate types.
   A homogeneous event summary is normalized as well. Ambiguous historical mixed-event summaries remain unchanged,
   while newly generated mixed events aggregate cadence and stroke rate separately.
-- Summary-only native event JSON receives the same normalization when its `Activity Types` stat is present.
-  Applications that persist neither activities nor that stat can call
+- Summary-only native event JSON removes Diving-group terrain summaries when its `Activity Types` stat is present,
+  while other summary semantics remain opt-in. Applications can call
   `normalizeActivityMetricSemanticsForStats(summary, contributingActivityTypes)` after hydration. This opt-in boundary
   canonicalizes unambiguous stroke-rate summaries and removes terrain summaries only for homogeneous Diving-group
   projections, keeping application persistence concerns outside Sports Lib while reusing its centralized sport-family

--- a/docs/guides/metrics-and-calculations.md
+++ b/docs/guides/metrics-and-calculations.md
@@ -142,8 +142,9 @@ Ascent/Loss uses thresholded step accumulation (default minDiff = 2):
 ```
 
 - Terrain ascent/descent, altitude min/max/avg, and grade min/max/avg are intentionally excluded for the Diving
-  activity group (Diving, Scuba Diving, Free Diving, Snorkeling, and Mermaiding), whether present in a source summary
-  or otherwise derived from streams. Their vertical movement is represented by depth, not terrain elevation.
+  activity group (Diving, Scuba Diving, Free Diving, Snorkeling, and Mermaiding), whether present in a source summary,
+  restored from native JSON, or otherwise derived from streams. Their vertical movement is represented by depth, not
+  terrain elevation.
 - Cadence and stroke-rate minimum/average values exclude zero values.
 - Grade max/min/avg prefers `Grade Smooth` when present.
 
@@ -159,9 +160,12 @@ Cadence and stroke-rate semantics are activity-aware:
   therefore does not need source-file reparsing; serializing the hydrated model writes the canonical stroke-rate types.
   A homogeneous event summary is normalized as well. Ambiguous historical mixed-event summaries remain unchanged,
   while newly generated mixed events aggregate cadence and stroke rate separately.
-- Applications that persist summary-only projections without their contributing activities can call
+- Summary-only native event JSON receives the same normalization when its `Activity Types` stat is present.
+  Applications that persist neither activities nor that stat can call
   `normalizeActivityMetricSemanticsForStats(summary, contributingActivityTypes)` after hydration. This opt-in boundary
-  keeps application persistence concerns outside Sports Lib while reusing its centralized sport-family policy.
+  canonicalizes unambiguous stroke-rate summaries and removes terrain summaries only for homogeneous Diving-group
+  projections, keeping application persistence concerns outside Sports Lib while reusing its centralized sport-family
+  policy.
 - Pool-swim length JSON retains the `avgCadence` key for storage compatibility, but its in-memory value is
   `DataStrokeRate` and its unit is `spm`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sports-alliance/sports-lib",
-  "version": "20.0.1",
+  "version": "20.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sports-alliance/sports-lib",
-      "version": "20.0.1",
+      "version": "20.0.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@googlemaps/polyline-codec": "^1.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sports-alliance/sports-lib",
-  "version": "20.0.1",
+  "version": "20.0.2",
   "description": "A Library to for importing / exporting and processing GPX, TCX, FIT and JSON files from services such as Strava, Movescount, Garmin, Polar etc",
   "keywords": [
     "gpx",

--- a/src/activities/activity.metric-semantics.spec.ts
+++ b/src/activities/activity.metric-semantics.spec.ts
@@ -3,6 +3,7 @@ import { DataCadence } from '../data/data.cadence';
 import { DataCadenceAvg } from '../data/data.cadence-avg';
 import { DataCadenceMax } from '../data/data.cadence-max';
 import { DataCadenceMin } from '../data/data.cadence-min';
+import { DataAscent } from '../data/data.ascent';
 import { DataHeartRate } from '../data/data.heart-rate';
 import { DataPower } from '../data/data.power';
 import { DataStrokeRate } from '../data/data.stroke-rate';
@@ -73,6 +74,19 @@ describe('activity metric semantics', () => {
 
     expect(event.getStat(DataCadenceAvg.type)?.getValue()).toBe(32);
     expect(event.getStat(DataStrokeRateAvg.type)).toBeUndefined();
+  });
+
+  it('removes terrain summaries only for homogeneous Diving-group stat projections', () => {
+    const divingSummary = new Event('Diving summary', new Date(0), new Date(1000), FileType.FIT, Privacy.Private);
+    divingSummary.addStat(new DataAscent(20));
+    const mixedSummary = new Event('Mixed summary', new Date(0), new Date(1000), FileType.FIT, Privacy.Private);
+    mixedSummary.addStat(new DataAscent(20));
+
+    normalizeActivityMetricSemanticsForStats(divingSummary, [ActivityTypes.ScubaDiving]);
+    normalizeActivityMetricSemanticsForStats(mixedSummary, [ActivityTypes.ScubaDiving, ActivityTypes.Running]);
+
+    expect(divingSummary.getStat(DataAscent.type)).toBeUndefined();
+    expect(mixedSummary.getStat(DataAscent.type)?.getValue()).toBe(20);
   });
 
   it.each(strokeRateActivityTypes)('normalizes cadence streams and summaries for %s', activityType => {

--- a/src/activities/activity.metric-semantics.ts
+++ b/src/activities/activity.metric-semantics.ts
@@ -87,9 +87,7 @@ export function normalizeActivityMetricSemanticsForStats(
   target: StatsClassInterface,
   activityTypes: readonly unknown[]
 ): void {
-  const resolvedActivityTypes = activityTypes
-    .map(activityType => ActivityTypesHelper.resolveActivityType(activityType))
-    .filter((activityType): activityType is ActivityTypes => activityType !== null);
+  const resolvedActivityTypes = resolveActivityTypes(activityTypes);
 
   if (resolvedActivityTypes.length === 0 || resolvedActivityTypes.length !== activityTypes.length) {
     return;
@@ -98,11 +96,7 @@ export function normalizeActivityMetricSemanticsForStats(
   if (resolvedActivityTypes.every(activityType => ActivityTypesHelper.usesStrokeRate(activityType))) {
     normalizeStrokeRateStats(target);
   }
-  if (
-    resolvedActivityTypes.every(activityType => ActivityTypesHelper.shouldExcludeTerrainSummaryMetrics(activityType))
-  ) {
-    DIVING_TERRAIN_SUMMARY_DATA_TYPES.forEach(dataType => target.removeStat(dataType));
-  }
+  removeExcludedTerrainSummaryMetricsForResolvedActivityTypes(target, resolvedActivityTypes);
 }
 
 /**
@@ -112,12 +106,23 @@ export function normalizeActivityMetricSemanticsForStats(
  */
 export function normalizeActivityMetricSemanticsForActivity(activity: ActivityInterface): void {
   normalizeStrokeRateSemanticsForActivity(activity);
-  if (!ActivityTypesHelper.shouldExcludeTerrainSummaryMetrics(activity.type)) {
+  removeExcludedTerrainSummaryMetricsForStats(activity, [activity.type]);
+  activity.getLaps().forEach(lap => removeExcludedTerrainSummaryMetricsForStats(lap, [activity.type]));
+}
+
+/**
+ * Removes terrain summaries that would misrepresent a homogeneous Diving-group
+ * summary. Source streams are deliberately left untouched.
+ */
+export function removeExcludedTerrainSummaryMetricsForStats(
+  target: StatsClassInterface,
+  activityTypes: readonly unknown[]
+): void {
+  const resolvedActivityTypes = resolveActivityTypes(activityTypes);
+  if (resolvedActivityTypes.length === 0 || resolvedActivityTypes.length !== activityTypes.length) {
     return;
   }
-
-  normalizeActivityMetricSemanticsForStats(activity, [activity.type]);
-  activity.getLaps().forEach(lap => normalizeActivityMetricSemanticsForStats(lap, [activity.type]));
+  removeExcludedTerrainSummaryMetricsForResolvedActivityTypes(target, resolvedActivityTypes);
 }
 
 /**
@@ -146,4 +151,20 @@ export function normalizeStrokeRateSemanticsForActivity(activity: ActivityInterf
 
   normalizeActivityMetricSemanticsForStats(activity, [activity.type]);
   activity.getLaps().forEach(lap => normalizeActivityMetricSemanticsForStats(lap, [activity.type]));
+}
+
+function resolveActivityTypes(activityTypes: readonly unknown[]): ActivityTypes[] {
+  return activityTypes
+    .map(activityType => ActivityTypesHelper.resolveActivityType(activityType))
+    .filter((activityType): activityType is ActivityTypes => activityType !== null);
+}
+
+function removeExcludedTerrainSummaryMetricsForResolvedActivityTypes(
+  target: StatsClassInterface,
+  activityTypes: readonly ActivityTypes[]
+): void {
+  if (!activityTypes.every(activityType => ActivityTypesHelper.shouldExcludeTerrainSummaryMetrics(activityType))) {
+    return;
+  }
+  DIVING_TERRAIN_SUMMARY_DATA_TYPES.forEach(dataType => target.removeStat(dataType));
 }

--- a/src/activities/activity.metric-semantics.ts
+++ b/src/activities/activity.metric-semantics.ts
@@ -1,7 +1,15 @@
+import { DataAltitudeAvg } from '../data/data.altitude-avg';
+import { DataAltitudeMax } from '../data/data.altitude-max';
+import { DataAltitudeMin } from '../data/data.altitude-min';
+import { DataAscent } from '../data/data.ascent';
 import { DataCadence } from '../data/data.cadence';
 import { DataCadenceAvg } from '../data/data.cadence-avg';
 import { DataCadenceMax } from '../data/data.cadence-max';
 import { DataCadenceMin } from '../data/data.cadence-min';
+import { DataDescent } from '../data/data.descent';
+import { DataGradeAvg } from '../data/data.grade-avg';
+import { DataGradeMax } from '../data/data.grade-max';
+import { DataGradeMin } from '../data/data.grade-min';
 import { DataInterface } from '../data/data.interface';
 import { DataStrokeRate } from '../data/data.stroke-rate';
 import { DataStrokeRateAvg } from '../data/data.stroke-rate-avg';
@@ -29,6 +37,17 @@ const CADENCE_TO_STROKE_RATE_STATS: MetricSemanticMapping[] = [
   { source: DataCadenceMax, target: DataStrokeRateMax }
 ];
 
+const DIVING_TERRAIN_SUMMARY_DATA_TYPES = [
+  DataAscent.type,
+  DataDescent.type,
+  DataAltitudeMin.type,
+  DataAltitudeMax.type,
+  DataAltitudeAvg.type,
+  DataGradeMin.type,
+  DataGradeMax.type,
+  DataGradeAvg.type
+] as const;
+
 /**
  * Re-labels cadence-shaped stats as stroke rate while preferring an explicitly supplied
  * stroke-rate value when both semantic families are present.
@@ -50,10 +69,12 @@ function normalizeStrokeRateStats(target: StatsClassInterface): void {
 /**
  * Canonicalizes summary metric semantics using every activity type represented by the stats.
  *
- * The target is mutated only when the supplied activity types are non-empty, all resolve to
- * canonical Sports Lib activity types, and all use stroke-rate semantics. Empty, unknown, and
- * mixed-family inputs are preserved because their cadence summaries are ambiguous. Explicit
- * stroke-rate stats take precedence over cadence-shaped compatibility values.
+ * The target is mutated only when the supplied activity types are non-empty and all resolve to
+ * canonical Sports Lib activity types. Homogeneous stroke-rate summaries convert cadence-shaped
+ * values, while homogeneous Diving-group summaries remove terrain values that misrepresent dive
+ * vertical movement. Empty, unknown, and mixed-family inputs are preserved because their
+ * semantics are ambiguous. Explicit stroke-rate stats take precedence over cadence-shaped
+ * compatibility values.
  *
  * Host applications that persist summary-only projections can call this after restoring the
  * projection and determining the activity types that contributed to it.
@@ -77,6 +98,26 @@ export function normalizeActivityMetricSemanticsForStats(
   if (resolvedActivityTypes.every(activityType => ActivityTypesHelper.usesStrokeRate(activityType))) {
     normalizeStrokeRateStats(target);
   }
+  if (
+    resolvedActivityTypes.every(activityType => ActivityTypesHelper.shouldExcludeTerrainSummaryMetrics(activityType))
+  ) {
+    DIVING_TERRAIN_SUMMARY_DATA_TYPES.forEach(dataType => target.removeStat(dataType));
+  }
+}
+
+/**
+ * Applies activity-aware stream and summary semantics to an activity and its laps. Source
+ * importers can remain protocol-focused and emit cadence-shaped fields; adding another supported
+ * stroke-rate sport only requires extending ActivityTypesHelper.usesStrokeRate().
+ */
+export function normalizeActivityMetricSemanticsForActivity(activity: ActivityInterface): void {
+  normalizeStrokeRateSemanticsForActivity(activity);
+  if (!ActivityTypesHelper.shouldExcludeTerrainSummaryMetrics(activity.type)) {
+    return;
+  }
+
+  normalizeActivityMetricSemanticsForStats(activity, [activity.type]);
+  activity.getLaps().forEach(lap => normalizeActivityMetricSemanticsForStats(lap, [activity.type]));
 }
 
 /**

--- a/src/events/adapters/importers/json/importer.json.compat.spec.ts
+++ b/src/events/adapters/importers/json/importer.json.compat.spec.ts
@@ -1,5 +1,6 @@
 import { EventImporterJSON } from './importer.json';
 import { ActivityTypes } from '../../../../activities/activity.types';
+import { DataActivityTypes } from '../../../../data/data.activity-types';
 import { DataAvgVAM } from '../../../../data/data.avg-vam';
 import { DataJumpHeightAvg } from '../../../../data/data.jump-stats';
 import { DataMaxHRSetting } from '../../../../data/data.max-hr-setting';
@@ -14,11 +15,43 @@ import { DataCadence } from '../../../../data/data.cadence';
 import { DataCadenceAvg } from '../../../../data/data.cadence-avg';
 import { DataStrokeRate } from '../../../../data/data.stroke-rate';
 import { DataStrokeRateAvg } from '../../../../data/data.stroke-rate-avg';
+import { DataAscent } from '../../../../data/data.ascent';
+import { DataDescent } from '../../../../data/data.descent';
+import { DataAltitudeMin } from '../../../../data/data.altitude-min';
+import { DataAltitudeMax } from '../../../../data/data.altitude-max';
+import { DataAltitudeAvg } from '../../../../data/data.altitude-avg';
+import { DataGradeMin } from '../../../../data/data.grade-min';
+import { DataGradeMax } from '../../../../data/data.grade-max';
+import { DataGradeAvg } from '../../../../data/data.grade-avg';
+import { DataAltitude } from '../../../../data/data.altitude';
+import { DataGrade } from '../../../../data/data.grade';
 import { LapTypes } from '../../../../laps/lap.types';
 import { FileType } from '../../file-type.enum';
 import { Privacy } from '../../../../privacy/privacy.class.interface';
 
 describe('EventImporterJSON legacy type compatibility', () => {
+  const divingTerrainSummaryTypes = [
+    DataAscent.type,
+    DataDescent.type,
+    DataAltitudeMin.type,
+    DataAltitudeMax.type,
+    DataAltitudeAvg.type,
+    DataGradeMin.type,
+    DataGradeMax.type,
+    DataGradeAvg.type
+  ];
+
+  const divingTerrainStats = {
+    [DataAscent.type]: 20,
+    [DataDescent.type]: 10,
+    [DataAltitudeMin.type]: -5,
+    [DataAltitudeMax.type]: 5,
+    [DataAltitudeAvg.type]: 0,
+    [DataGradeMin.type]: -10,
+    [DataGradeMax.type]: 10,
+    [DataGradeAvg.type]: 0
+  };
+
   it('normalizes stored cadence streams and summaries using activity semantics', () => {
     const activity = EventImporterJSON.getActivityFromJSON({
       name: 'stored-open-water-swim',
@@ -88,6 +121,103 @@ describe('EventImporterJSON legacy type compatibility', () => {
     expect(event.getStat(DataCadenceAvg.type)).toBeUndefined();
     expect(event.getStat(DataStrokeRateAvg.type)?.getValue()).toBe(28);
     expect(event.getFirstActivity().getStat(DataStrokeRateAvg.type)?.getValue()).toBe(28);
+  });
+
+  it.each([
+    ActivityTypes.Diving,
+    ActivityTypes.ScubaDiving,
+    ActivityTypes.FreeDiving,
+    ActivityTypes.Snorkeling,
+    ActivityTypes.Mermaiding
+  ])('removes stored terrain summaries for %s without removing source streams', activityType => {
+    const event = EventImporterJSON.getEventFromJSON({
+      name: 'stored-dive-event',
+      startDate: 0,
+      endDate: 1000,
+      srcFileType: FileType.FIT,
+      description: null,
+      isMerge: false,
+      privacy: Privacy.Private,
+      powerCurve: null,
+      stats: {
+        [DataActivityTypes.type]: [activityType],
+        ...divingTerrainStats
+      },
+      activities: [
+        {
+          name: null,
+          startDate: 0,
+          endDate: 1000,
+          type: activityType,
+          powerMeter: false,
+          trainer: false,
+          powerCurve: null,
+          stats: divingTerrainStats,
+          streams: [
+            { type: DataAltitude.type, data: [-5, 0, 5] },
+            { type: DataGrade.type, data: [-10, 0, 10] }
+          ],
+          laps: [
+            {
+              lapId: 1,
+              startDate: 0,
+              endDate: 1000,
+              startIndex: null,
+              endIndex: null,
+              type: LapTypes.Manual,
+              stats: divingTerrainStats
+            }
+          ],
+          creator: { name: 'test', devices: [] },
+          intensityZones: [],
+          events: []
+        }
+      ]
+    });
+    const activity = event.getFirstActivity();
+    const lap = activity.getLaps()[0];
+
+    [event, activity, lap].forEach(target => {
+      divingTerrainSummaryTypes.forEach(dataType => expect(target.getStat(dataType)).toBeUndefined());
+    });
+    expect(activity.getStreamData(DataAltitude.type)).toEqual([-5, 0, 5]);
+    expect(activity.getStreamData(DataGrade.type)).toEqual([-10, 0, 10]);
+  });
+
+  it('uses a summary-only event activity-type stat and preserves mixed terrain summaries', () => {
+    const divingEvent = EventImporterJSON.getEventFromJSON({
+      name: 'stored-summary-only-dive',
+      startDate: 0,
+      endDate: 1000,
+      srcFileType: FileType.FIT,
+      description: null,
+      isMerge: false,
+      privacy: Privacy.Private,
+      powerCurve: null,
+      stats: {
+        [DataActivityTypes.type]: [ActivityTypes.ScubaDiving],
+        ...divingTerrainStats
+      },
+      activities: []
+    });
+    const mixedEvent = EventImporterJSON.getEventFromJSON({
+      name: 'stored-mixed-summary',
+      startDate: 0,
+      endDate: 1000,
+      srcFileType: FileType.FIT,
+      description: null,
+      isMerge: false,
+      privacy: Privacy.Private,
+      powerCurve: null,
+      stats: {
+        [DataActivityTypes.type]: [ActivityTypes.ScubaDiving, ActivityTypes.Running],
+        ...divingTerrainStats
+      },
+      activities: []
+    });
+
+    divingTerrainSummaryTypes.forEach(dataType => expect(divingEvent.getStat(dataType)).toBeUndefined());
+    expect(mixedEvent.getStat(DataAscent.type)?.getValue()).toBe(20);
   });
 
   it('maps legacy stat keys to canonical types via DynamicDataLoader aliases', () => {

--- a/src/events/adapters/importers/json/importer.json.ts
+++ b/src/events/adapters/importers/json/importer.json.ts
@@ -16,7 +16,8 @@ import { ActivityJSONInterface } from '../../../../activities/activity.json.inte
 import { ActivityTypes } from '../../../../activities/activity.types';
 import {
   normalizeActivityMetricSemanticsForStats,
-  normalizeActivityMetricSemanticsForActivity
+  normalizeActivityMetricSemanticsForActivity,
+  removeExcludedTerrainSummaryMetricsForStats
 } from '../../../../activities/activity.metric-semantics';
 import { IntensityZonesJSONInterface } from '../../../../intensity-zones/intensity-zones.json.interface';
 import { StreamInterface } from '../../../../streams/stream.interface';
@@ -60,12 +61,14 @@ export class EventImporterJSON {
       event.addActivity(this.getActivityFromJSON(activityJSON));
     });
     const activities = event.getActivities();
-    const activityTypes =
-      activities.length > 0
-        ? activities.map(activity => activity.type)
-        : event.getStat<unknown>(DataActivityTypes.type)?.getValue();
-    const resolvedActivityTypes = Array.isArray(activityTypes) ? activityTypes : [];
-    normalizeActivityMetricSemanticsForStats(event, resolvedActivityTypes);
+    const activityTypes = activities.map(activity => activity.type);
+    normalizeActivityMetricSemanticsForStats(event, activityTypes);
+    if (activityTypes.length === 0) {
+      const summaryActivityTypes = event.getStat<unknown>(DataActivityTypes.type)?.getValue();
+      if (Array.isArray(summaryActivityTypes)) {
+        removeExcludedTerrainSummaryMetricsForStats(event, summaryActivityTypes);
+      }
+    }
     return event;
   }
 

--- a/src/events/adapters/importers/json/importer.json.ts
+++ b/src/events/adapters/importers/json/importer.json.ts
@@ -16,7 +16,7 @@ import { ActivityJSONInterface } from '../../../../activities/activity.json.inte
 import { ActivityTypes } from '../../../../activities/activity.types';
 import {
   normalizeActivityMetricSemanticsForStats,
-  normalizeStrokeRateSemanticsForActivity
+  normalizeActivityMetricSemanticsForActivity
 } from '../../../../activities/activity.metric-semantics';
 import { IntensityZonesJSONInterface } from '../../../../intensity-zones/intensity-zones.json.interface';
 import { StreamInterface } from '../../../../streams/stream.interface';
@@ -30,15 +30,16 @@ import { DataJSONInterface } from '../../../../data/data.json.interface';
 import { DataEvent } from '../../../../data/data.event';
 import { DataTime } from '../../../../data/data.time';
 import { DataPowerCurve } from '../../../../data/data.power-curve';
+import { DataActivityTypes } from '../../../../data/data.activity-types';
 import { SwimLength } from '../../../../swim-lengths/swim-length';
 import { StatsClassInterface } from '../../../../stats/stats.class.interface';
 import { hydrateMissingSpeedDerivedStats } from '../../../../stats/speed-derived-stats';
 
 export class EventImporterJSON {
   /**
-   * Restores a native JSON event, canonicalizing stat keys and activity-aware stroke-rate
-   * semantics while hydrating missing speed-derived pace summaries on the event, its activities,
-   * and their laps.
+   * Restores a native JSON event, canonicalizing stat keys and activity-aware summary semantics
+   * while hydrating missing speed-derived pace summaries on the event, its activities, and their
+   * laps.
    */
   static getEventFromJSON(json: EventJSONInterface): EventInterface {
     const event = new Event(
@@ -59,10 +60,12 @@ export class EventImporterJSON {
       event.addActivity(this.getActivityFromJSON(activityJSON));
     });
     const activities = event.getActivities();
-    normalizeActivityMetricSemanticsForStats(
-      event,
-      activities.map(activity => activity.type)
-    );
+    const activityTypes =
+      activities.length > 0
+        ? activities.map(activity => activity.type)
+        : event.getStat<unknown>(DataActivityTypes.type)?.getValue();
+    const resolvedActivityTypes = Array.isArray(activityTypes) ? activityTypes : [];
+    normalizeActivityMetricSemanticsForStats(event, resolvedActivityTypes);
     return event;
   }
 
@@ -282,7 +285,7 @@ export class EventImporterJSON {
   }
 
   /**
-   * Restores a native JSON activity, normalizes activity-aware stroke-rate semantics, and hydrates
+   * Restores a native JSON activity, normalizes activity-aware summary semantics, and hydrates
    * missing speed-derived pace summaries on it and its laps.
    */
   static getActivityFromJSON(json: ActivityJSONInterface): ActivityInterface {
@@ -318,7 +321,7 @@ export class EventImporterJSON {
         activity.addEvent(this.getActivityEventFromJSON(activityEvent));
       });
     }
-    normalizeStrokeRateSemanticsForActivity(activity);
+    normalizeActivityMetricSemanticsForActivity(activity);
     return activity;
   }
 }

--- a/src/events/utilities/activity.utilities.ts
+++ b/src/events/utilities/activity.utilities.ts
@@ -302,7 +302,7 @@ import { DataAltitudeSmooth } from '../../data/data.altitude-smooth';
 import { DataGradeSmooth } from '../../data/data.grade-smooth';
 import { DataSWOLF25m } from '../../data/data.swolf-25m';
 import { DataSWOLF50m } from '../../data/data.swolf-50m';
-import { normalizeStrokeRateSemanticsForActivity } from '../../activities/activity.metric-semantics';
+import { normalizeActivityMetricSemanticsForActivity } from '../../activities/activity.metric-semantics';
 
 import { LowPassFilter } from './grade-calculator/low-pass-filter';
 import { DataPowerIntensityFactor } from '../../data/data.power-intensity-factor';
@@ -376,16 +376,6 @@ export class ActivityUtilities {
   private static readonly FTP_FACTOR = 0.95;
   private static readonly INTENSITY_FACTOR_DECIMALS = 3;
   private static readonly TRAINING_STRESS_SCORE_DECIMALS = 1;
-  private static readonly DIVING_TERRAIN_SUMMARY_DATA_TYPES = [
-    DataAscent.type,
-    DataDescent.type,
-    DataAltitudeMin.type,
-    DataAltitudeMax.type,
-    DataAltitudeAvg.type,
-    DataGradeMin.type,
-    DataGradeMax.type,
-    DataGradeAvg.type
-  ];
   private static readonly jumpStatFamilies: Array<{
     key: string;
     minType: string;
@@ -907,8 +897,7 @@ export class ActivityUtilities {
    * excluded for Diving activities.
    */
   public static generateMissingStreamsAndStatsForActivity(activity: ActivityInterface): void {
-    normalizeStrokeRateSemanticsForActivity(activity);
-    this.removeExcludedTerrainSummaryMetrics(activity);
+    normalizeActivityMetricSemanticsForActivity(activity);
     this.generateMissingStreams(activity);
     this.fixAbnormalStreamData(activity);
     this.generateMissingStatsForActivity(activity);
@@ -937,22 +926,6 @@ export class ActivityUtilities {
     }
 
     this.generateMissingUnitStatsForActivity(activity); // Perhaps this needs to happen on user level so needs to go out of here
-  }
-
-  /**
-   * Removes terrain summaries that would misrepresent a diving activity. This is
-   * intentionally applied before hydration so all importers and restored activities
-   * share the same rule, including their lap summaries.
-   */
-  private static removeExcludedTerrainSummaryMetrics(activity: ActivityInterface): void {
-    if (!ActivityTypesHelper.shouldExcludeTerrainSummaryMetrics(activity.type)) {
-      return;
-    }
-
-    const summaryTargets: StatsClassInterface[] = [activity, ...activity.getLaps()];
-    summaryTargets.forEach(target => {
-      this.DIVING_TERRAIN_SUMMARY_DATA_TYPES.forEach(dataType => target.removeStat(dataType));
-    });
   }
 
   public static fixAbnormalStreamData(activity: ActivityInterface): void {


### PR DESCRIPTION
## Summary
- apply the shared Diving-group terrain-summary rule during native JSON hydration
- cover event, activity, lap, summary-only, mixed-sport, and raw-stream behavior
- bump the package to 20.0.2 with native-JSON migration guidance

## Validation
- `npm test -- --runInBand`
- `npm run docs:build`
- `npm run build`
- scoped ESLint (repository-wide lint has pre-existing unrelated failures)
- `npm pack --dry-run --json`