### PR TITLE
fix: exclude diving terrain from regenerated summaries

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,8 +19,8 @@ places, rates to three, SAC/RMV values to two, and PO₂ retains both FIT decima
 Garmin single-gas, multi-gas, and gauge sub-sports import as `Scuba Diving`; apnea sub-sports import as `Free Diving`.
 FIT session and lap intensity enums are retained as the string-valued `Intensity` stat. Diving-group activities do not
 retain or derive terrain ascent, descent, altitude min/max/avg, or grade min/max/avg summaries, including when older
-native JSON is restored. Their vertical movement is represented by depth; raw altitude and grade streams remain
-available when provided by the source.
+native JSON is restored or an all-diving event summary is regenerated. Their vertical movement is represented by depth;
+raw altitude and grade streams remain available when provided by the source.
 
 ## Start here
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,8 +19,9 @@ places, rates to three, SAC/RMV values to two, and PO₂ retains both FIT decima
 Garmin single-gas, multi-gas, and gauge sub-sports import as `Scuba Diving`; apnea sub-sports import as `Free Diving`.
 FIT session and lap intensity enums are retained as the string-valued `Intensity` stat. Diving-group activities do not
 retain or derive terrain ascent, descent, altitude min/max/avg, or grade min/max/avg summaries, including when older
-native JSON is restored or an all-diving event summary is regenerated. Their vertical movement is represented by depth;
-raw altitude and grade streams remain available when provided by the source.
+native JSON is restored or an all-diving event summary is regenerated. Mixed event summaries use terrain values only
+from non-diving activities. Their vertical movement is represented by depth; raw altitude and grade streams remain
+available when provided by the source.
 
 ## Start here
 

--- a/docs/api.ts
+++ b/docs/api.ts
@@ -328,7 +328,7 @@ export type {
 /**
  * Event aggregation and regeneration. Generated homogeneous Diving-group event summaries omit
  * terrain ascent/descent, altitude min/max/avg, and grade min/max/avg; mixed event summaries
- * retain their terrain metrics.
+ * aggregate those metrics only from their non-diving activities.
  *
  * @category Activities and events
  */

--- a/docs/api.ts
+++ b/docs/api.ts
@@ -325,4 +325,11 @@ export type {
   ThreeDimensionalImpulseResponseCalibrationStatus,
   ThreeDimensionalPerformanceObservation
 } from '../src/events/utilities/three-dimensional-impulse-response-calibration';
+/**
+ * Event aggregation and regeneration. Generated homogeneous Diving-group event summaries omit
+ * terrain ascent/descent, altitude min/max/avg, and grade min/max/avg; mixed event summaries
+ * retain their terrain metrics.
+ *
+ * @category Activities and events
+ */
 export { EventUtilities } from '../src/events/utilities/event.utilities';

--- a/docs/guides/importing-activities.md
+++ b/docs/guides/importing-activities.md
@@ -57,8 +57,9 @@ Garmin `single_gas_diving`, `multi_gas_diving`, and `gauge_diving` sub-sports re
 Diving activity group.
 
 Diving activities exclude terrain summaries—`Ascent`, `Descent`, altitude min/max/avg, and grade min/max/avg—whether
-they were imported from a FIT summary, restored from native JSON, or would otherwise be hydrated from streams. Depth
-represents dive vertical movement. Any source altitude or grade stream remains available when explicitly requested.
+they were imported from a FIT summary, restored from native JSON, regenerated into an all-diving event summary, or
+would otherwise be hydrated from streams. Depth represents dive vertical movement. Any source altitude or grade stream
+remains available when explicitly requested.
 
 FIT session and lap `intensity` enums are retained as the string-valued `Intensity` stat. Values follow the FIT profile,
 such as `active`, `rest`, `warmup`, `cooldown`, `recovery`, `interval`, and `other`.

--- a/docs/guides/importing-activities.md
+++ b/docs/guides/importing-activities.md
@@ -58,8 +58,9 @@ Diving activity group.
 
 Diving activities exclude terrain summaries—`Ascent`, `Descent`, altitude min/max/avg, and grade min/max/avg—whether
 they were imported from a FIT summary, restored from native JSON, regenerated into an all-diving event summary, or
-would otherwise be hydrated from streams. Depth represents dive vertical movement. Any source altitude or grade stream
-remains available when explicitly requested.
+would otherwise be hydrated from streams. Mixed event summaries aggregate terrain values only from non-diving
+activities. Depth represents dive vertical movement. Any source altitude or grade stream remains available when
+explicitly requested.
 
 FIT session and lap `intensity` enums are retained as the string-valued `Intensity` stat. Values follow the FIT profile,
 such as `active`, `rest`, `warmup`, `cooldown`, `recovery`, `interval`, and `other`.
@@ -92,6 +93,12 @@ application-specific persistence layout.
 Restoring existing Diving-group native JSON now removes terrain ascent/descent, altitude min/max/avg, and grade
 min/max/avg summary values from events, activities, and laps. No source-file reparse is needed for the restored
 in-memory model. Re-serializing that model intentionally omits those values; raw source streams remain untouched.
+
+### 20.0.3 regenerated-event correction
+
+Regenerating an event from Diving-group activities now omits those terrain summaries, and a mixed event takes them only
+from its non-diving activities. No source-file reparse is needed; regenerate and reserialize the event summary when an
+application persists regenerated summaries.
 
 Activities expose one-second streams and typed stats. Read numeric values with `getValue()` and display-ready values with
 `getDisplayValue()`. Depth presentation follows the first swim-pace preference: `/100m` selects meters and `/100yd`

--- a/docs/guides/metrics-and-calculations.md
+++ b/docs/guides/metrics-and-calculations.md
@@ -143,8 +143,9 @@ Ascent/Loss uses thresholded step accumulation (default minDiff = 2):
 
 - Terrain ascent/descent, altitude min/max/avg, and grade min/max/avg are intentionally excluded for the Diving
   activity group (Diving, Scuba Diving, Free Diving, Snorkeling, and Mermaiding), whether present in a source summary,
-  restored from native JSON, regenerated into an all-diving event summary, or otherwise derived from streams. Their
-  vertical movement is represented by depth, not terrain elevation.
+  restored from native JSON, regenerated into an all-diving event summary, or otherwise derived from streams. Mixed
+  event summaries aggregate these metrics only from non-diving activities. Their vertical movement is represented by
+  depth, not terrain elevation.
 - Cadence and stroke-rate minimum/average values exclude zero values.
 - Grade max/min/avg prefers `Grade Smooth` when present.
 

--- a/docs/guides/metrics-and-calculations.md
+++ b/docs/guides/metrics-and-calculations.md
@@ -143,8 +143,8 @@ Ascent/Loss uses thresholded step accumulation (default minDiff = 2):
 
 - Terrain ascent/descent, altitude min/max/avg, and grade min/max/avg are intentionally excluded for the Diving
   activity group (Diving, Scuba Diving, Free Diving, Snorkeling, and Mermaiding), whether present in a source summary,
-  restored from native JSON, or otherwise derived from streams. Their vertical movement is represented by depth, not
-  terrain elevation.
+  restored from native JSON, regenerated into an all-diving event summary, or otherwise derived from streams. Their
+  vertical movement is represented by depth, not terrain elevation.
 - Cadence and stroke-rate minimum/average values exclude zero values.
 - Grade max/min/avg prefers `Grade Smooth` when present.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sports-alliance/sports-lib",
-  "version": "20.0.2",
+  "version": "20.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sports-alliance/sports-lib",
-      "version": "20.0.2",
+      "version": "20.0.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@googlemaps/polyline-codec": "^1.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sports-alliance/sports-lib",
-  "version": "20.0.2",
+  "version": "20.0.3",
   "description": "A Library to for importing / exporting and processing GPX, TCX, FIT and JSON files from services such as Strava, Movescount, Garmin, Polar etc",
   "keywords": [
     "gpx",

--- a/src/events/utilities/activity.utilities.ts
+++ b/src/events/utilities/activity.utilities.ts
@@ -988,6 +988,10 @@ export class ActivityUtilities {
         );
     }
 
+    const terrainSummaryActivities = activities.filter(
+      activity => !ActivityTypesHelper.shouldExcludeTerrainSummaryMetrics(activity.type)
+    );
+
     let duration = 0;
     let ascent = 0;
     let descent = 0;
@@ -1051,22 +1055,26 @@ export class ActivityUtilities {
     stats.push(new DataDistance(distance));
 
     // Sum ascent
-    activities.forEach(activity => {
-      const activityAscent = activity.getStat(DataAscent.type);
-      if (activityAscent) {
-        ascent += <number>activityAscent.getValue();
-      }
-    });
-    stats.push(new DataAscent(ascent));
+    if (terrainSummaryActivities.length > 0) {
+      terrainSummaryActivities.forEach(activity => {
+        const activityAscent = activity.getStat(DataAscent.type);
+        if (activityAscent) {
+          ascent += <number>activityAscent.getValue();
+        }
+      });
+      stats.push(new DataAscent(ascent));
+    }
 
     // Sum descent
-    activities.forEach(activity => {
-      const activityDescent = activity.getStat(DataDescent.type);
-      if (activityDescent) {
-        descent += <number>activityDescent.getValue();
-      }
-    });
-    stats.push(new DataDescent(descent));
+    if (terrainSummaryActivities.length > 0) {
+      terrainSummaryActivities.forEach(activity => {
+        const activityDescent = activity.getStat(DataDescent.type);
+        if (activityDescent) {
+          descent += <number>activityDescent.getValue();
+        }
+      });
+      stats.push(new DataDescent(descent));
+    }
 
     // Sum energy
     activities.forEach(activity => {
@@ -1343,7 +1351,7 @@ export class ActivityUtilities {
     }
 
     // Avg Grade
-    activities.forEach(activity => {
+    terrainSummaryActivities.forEach(activity => {
       const activityAvgGrade = activity.getStat(DataGradeAvg.type);
       if (activityAvgGrade) {
         averageGrade = hasAverageGrade
@@ -1383,7 +1391,7 @@ export class ActivityUtilities {
     }
 
     // Avg Avg Altitude
-    activities.forEach(activity => {
+    terrainSummaryActivities.forEach(activity => {
       const activityAvgAltitude = activity.getStat(DataAltitudeAvg.type);
       if (activityAvgAltitude) {
         averageAltitude = averageAltitude
@@ -1640,7 +1648,7 @@ export class ActivityUtilities {
 
     // Max Altitude
     let maxAltitude = -Infinity;
-    activities.forEach(activity => {
+    terrainSummaryActivities.forEach(activity => {
       const activityMaxAltitude = activity.getStat(DataAltitudeMax.type);
       if (activityMaxAltitude) {
         maxAltitude = Math.max(maxAltitude, <number>activityMaxAltitude.getValue());
@@ -1652,7 +1660,7 @@ export class ActivityUtilities {
 
     // Min Altitude
     let minAltitude = Infinity;
-    activities.forEach(activity => {
+    terrainSummaryActivities.forEach(activity => {
       const activityMinAltitude = activity.getStat(DataAltitudeMin.type);
       if (activityMinAltitude) {
         minAltitude = Math.min(minAltitude, <number>activityMinAltitude.getValue());
@@ -1964,7 +1972,7 @@ export class ActivityUtilities {
 
     // Max Grade
     let maxGrade = -Infinity;
-    activities.forEach(activity => {
+    terrainSummaryActivities.forEach(activity => {
       const activityMaxGrade = activity.getStat(DataGradeMax.type);
       if (activityMaxGrade) {
         maxGrade = Math.max(maxGrade, <number>activityMaxGrade.getValue());
@@ -1976,7 +1984,7 @@ export class ActivityUtilities {
 
     // Min Grade
     let minGrade = Infinity;
-    activities.forEach(activity => {
+    terrainSummaryActivities.forEach(activity => {
       const activityMinGrade = activity.getStat(DataGradeMin.type);
       if (activityMinGrade) {
         minGrade = Math.min(minGrade, <number>activityMinGrade.getValue());

--- a/src/events/utilities/event.utilities.aggregation.spec.ts
+++ b/src/events/utilities/event.utilities.aggregation.spec.ts
@@ -54,16 +54,16 @@ describe('EventUtilities Power Curve Aggregation', () => {
     DataGradeAvg.type
   ];
 
-  const addTerrainSummaryStats = (activity: Activity) => {
+  const addTerrainSummaryStats = (activity: Activity, scale = 1) => {
     [
-      new DataAscent(20),
-      new DataDescent(15),
-      new DataAltitudeMin(-5),
-      new DataAltitudeMax(5),
-      new DataAltitudeAvg(1),
-      new DataGradeMin(-10),
-      new DataGradeMax(10),
-      new DataGradeAvg(0)
+      new DataAscent(20 * scale),
+      new DataDescent(15 * scale),
+      new DataAltitudeMin(-5 * scale),
+      new DataAltitudeMax(5 * scale),
+      new DataAltitudeAvg(scale),
+      new DataGradeMin(-10 * scale),
+      new DataGradeMax(10 * scale),
+      new DataGradeAvg(scale)
     ].forEach(stat => activity.addStat(stat));
   };
 
@@ -174,10 +174,14 @@ describe('EventUtilities Power Curve Aggregation', () => {
 
   it('omits terrain summaries when regenerating an event made entirely of Diving-group activities', () => {
     const event = new Event('Two dives', new Date(0), new Date(120_000), FileType.FIT);
-    event.addActivities([
+    const activities = [
       createDivingActivity(ActivityTypes.ScubaDiving, 0),
       createDivingActivity(ActivityTypes.FreeDiving, 60_000)
-    ]);
+    ];
+    event.addActivities(activities);
+
+    const summaryStats = ActivityUtilities.getSummaryStatsForActivities(activities);
+    terrainSummaryTypes.forEach(type => expect(summaryStats.find(stat => stat.getType() === type)).toBeUndefined());
 
     EventUtilities.reGenerateStatsForEvent(event);
 
@@ -193,12 +197,16 @@ describe('EventUtilities Power Curve Aggregation', () => {
       new Creator('Running watch')
     );
     [new DataDuration(60), new DataPause(0), new DataDistance(100)].forEach(stat => running.addStat(stat));
-    addTerrainSummaryStats(running);
+    addTerrainSummaryStats(running, 5);
     event.addActivities([createDivingActivity(ActivityTypes.ScubaDiving, 0), running]);
 
     EventUtilities.reGenerateStatsForEvent(event);
 
     terrainSummaryTypes.forEach(type => expect(event.getStat(type)).toBeDefined());
+    expect(event.getStat(DataAscent.type)?.getValue()).toBe(100);
+    expect(event.getStat(DataDescent.type)?.getValue()).toBe(75);
+    expect(event.getStat(DataAltitudeAvg.type)?.getValue()).toBe(5);
+    expect(event.getStat(DataGradeAvg.type)?.getValue()).toBe(5);
   });
 
   describe('mergeEvents summary stats integration', () => {

--- a/src/events/utilities/event.utilities.aggregation.spec.ts
+++ b/src/events/utilities/event.utilities.aggregation.spec.ts
@@ -32,8 +32,54 @@ import { DataDistance } from '../../data/data.distance';
 import { DataEffortPaceAvg } from '../../data/data.effort-pace-avg';
 import { DataEffortPaceMin } from '../../data/data.effort-pace-min';
 import { DataEffortPaceMax } from '../../data/data.effort-pace-max';
+import { Creator } from '../../creators/creator';
+import { FileType } from '../adapters/file-type.enum';
+import { DataAscent } from '../../data/data.ascent';
+import { DataDescent } from '../../data/data.descent';
+import { DataAltitudeMin } from '../../data/data.altitude-min';
+import { DataAltitudeMax } from '../../data/data.altitude-max';
+import { DataGradeMin } from '../../data/data.grade-min';
+import { DataGradeMax } from '../../data/data.grade-max';
+import { DataGradeAvg } from '../../data/data.grade-avg';
 
 describe('EventUtilities Power Curve Aggregation', () => {
+  const terrainSummaryTypes = [
+    DataAscent.type,
+    DataDescent.type,
+    DataAltitudeMin.type,
+    DataAltitudeMax.type,
+    DataAltitudeAvg.type,
+    DataGradeMin.type,
+    DataGradeMax.type,
+    DataGradeAvg.type
+  ];
+
+  const addTerrainSummaryStats = (activity: Activity) => {
+    [
+      new DataAscent(20),
+      new DataDescent(15),
+      new DataAltitudeMin(-5),
+      new DataAltitudeMax(5),
+      new DataAltitudeAvg(1),
+      new DataGradeMin(-10),
+      new DataGradeMax(10),
+      new DataGradeAvg(0)
+    ].forEach(stat => activity.addStat(stat));
+  };
+
+  const createDivingActivity = (activityType: ActivityTypes, offsetMilliseconds: number) => {
+    const startDate = new Date(offsetMilliseconds);
+    const activity = new Activity(
+      startDate,
+      new Date(offsetMilliseconds + 60_000),
+      activityType,
+      new Creator('Dive computer')
+    );
+    [new DataDuration(60), new DataPause(0), new DataDistance(25)].forEach(stat => activity.addStat(stat));
+    addTerrainSummaryStats(activity);
+    return activity;
+  };
+
   const createMockActivity = (powerValues: number[], weight?: number): Activity => {
     const startDate = new Date();
     const endDate = new Date(startDate.getTime() + powerValues.length * 1000);
@@ -124,6 +170,35 @@ describe('EventUtilities Power Curve Aggregation', () => {
 
     expect(point10s.wattsPerKg).toBeDefined();
     expect(point10s.wattsPerKg.getValue()).toBe(4.0); // Should take the higher W/kg
+  });
+
+  it('omits terrain summaries when regenerating an event made entirely of Diving-group activities', () => {
+    const event = new Event('Two dives', new Date(0), new Date(120_000), FileType.FIT);
+    event.addActivities([
+      createDivingActivity(ActivityTypes.ScubaDiving, 0),
+      createDivingActivity(ActivityTypes.FreeDiving, 60_000)
+    ]);
+
+    EventUtilities.reGenerateStatsForEvent(event);
+
+    terrainSummaryTypes.forEach(type => expect(event.getStat(type)).toBeUndefined());
+  });
+
+  it('retains terrain summaries for a mixed regenerated event', () => {
+    const event = new Event('Dive and run', new Date(0), new Date(120_000), FileType.FIT);
+    const running = new Activity(
+      new Date(60_000),
+      new Date(120_000),
+      ActivityTypes.Running,
+      new Creator('Running watch')
+    );
+    [new DataDuration(60), new DataPause(0), new DataDistance(100)].forEach(stat => running.addStat(stat));
+    addTerrainSummaryStats(running);
+    event.addActivities([createDivingActivity(ActivityTypes.ScubaDiving, 0), running]);
+
+    EventUtilities.reGenerateStatsForEvent(event);
+
+    terrainSummaryTypes.forEach(type => expect(event.getStat(type)).toBeDefined());
   });
 
   describe('mergeEvents summary stats integration', () => {

--- a/src/events/utilities/event.utilities.ts
+++ b/src/events/utilities/event.utilities.ts
@@ -59,7 +59,8 @@ export class EventUtilities {
    * - Single-activity event: copies current summary-eligible activity stats into the event.
    * - Multi-activity event: recomputes event summary stats from activity stats and aggregates power curves.
    * - The resulting event summary is canonicalized for its contributing activity types. In particular, an
-   *   all-Diving-group event omits terrain ascent/descent, altitude, and grade summaries.
+   *   all-Diving-group event omits terrain ascent/descent, altitude, and grade summaries; mixed events aggregate
+   *   those summaries only from their non-diving activities.
    *
    * Interaction with `generateStatsForAll(event)`:
    * - `generateStatsForAll` calls activity generation first (`generateMissingStreamsAndStatsForActivity`),

--- a/src/events/utilities/event.utilities.ts
+++ b/src/events/utilities/event.utilities.ts
@@ -10,6 +10,7 @@ import { DataPowerCurve, DataPowerCurvePoint } from '../../data/data.power-curve
 import { DataDuration } from '../../data/data.duration';
 import { DataPower } from '../../data/data.power';
 import { DataPowerWattsPerKg } from '../../data/data.power-watts-per-kg';
+import { normalizeActivityMetricSemanticsForStats } from '../../activities/activity.metric-semantics';
 
 export class EventUtilities {
   public static mergeEvents(events: EventInterface[]): EventInterface {
@@ -57,6 +58,8 @@ export class EventUtilities {
    * Regeneration model:
    * - Single-activity event: copies current summary-eligible activity stats into the event.
    * - Multi-activity event: recomputes event summary stats from activity stats and aggregates power curves.
+   * - The resulting event summary is canonicalized for its contributing activity types. In particular, an
+   *   all-Diving-group event omits terrain ascent/descent, altitude, and grade summaries.
    *
    * Interaction with `generateStatsForAll(event)`:
    * - `generateStatsForAll` calls activity generation first (`generateMissingStreamsAndStatsForActivity`),
@@ -73,13 +76,15 @@ export class EventUtilities {
     event.clearStats();
     event.startDate = event.getFirstActivity().startDate;
     event.endDate = event.getLastActivity().endDate;
+    const activities = event.getActivities();
+    const activityTypes = activities.map(activity => activity.type);
 
-    event.addStat(new DataActivityTypes(event.getActivities().map(activity => activity.type)));
-    event.addStat(new DataDeviceNames(event.getActivities().map(activity => activity.creator.name)));
+    event.addStat(new DataActivityTypes(activityTypes));
+    event.addStat(new DataDeviceNames(activities.map(activity => activity.creator.name)));
 
     // If only one
-    if (event.getActivities().length === 1) {
-      const firstActivity = event.getFirstActivity();
+    if (activities.length === 1) {
+      const firstActivity = activities[0];
       ActivityUtilities.getSummaryStatsForActivities([firstActivity]).forEach(stat => {
         event.addStat(stat);
       });
@@ -93,16 +98,15 @@ export class EventUtilities {
       if (description && description.getValue()) {
         event.description = <string>description.getValue();
       }
-      return;
+    } else {
+      // Standard stat summarization
+      ActivityUtilities.getSummaryStatsForActivities(activities).forEach(stat => event.addStat(stat));
+
+      // Special handling for Power Curve Aggregation
+      this.aggregatePowerCurves(event);
     }
-    event.startDate = event.getFirstActivity().startDate;
-    event.endDate = event.getLastActivity().endDate;
 
-    // Standard stat summarization
-    ActivityUtilities.getSummaryStatsForActivities(event.getActivities()).forEach(stat => event.addStat(stat));
-
-    // Special handling for Power Curve Aggregation
-    this.aggregatePowerCurves(event);
+    normalizeActivityMetricSemanticsForStats(event, activityTypes);
   }
 
   private static aggregatePowerCurves(event: EventInterface): void {


### PR DESCRIPTION
## Summary
- omit terrain summaries from all-Diving-group regenerated events
- aggregate terrain values in mixed events only from non-diving activities
- release the correction as `20.0.3`

## Validation
- `npm test -- --runInBand` (105 suites, 1,867 tests)
- `npm run build`
- `npm run docs:build`
- `npm pack --dry-run --json`