### PR TITLE
feat: expose source-native dive gas and tank records

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,8 +11,10 @@ summaries separately from activities can explicitly canonicalize those projectio
 `normalizeActivityMetricSemanticsForStats` after determining the contributing activity types.
 
 FIT imports retain parser-scaled record depth samples in canonical meters and native session/lap dive summaries plus
-decompression, gas-consumption, tissue-load, PO₂, ascent-rate, and air-time-remaining record streams. These values follow
-the FIT profile without record-to-summary calculation, interpolation, clamping, or gas/tank flattening. Depth,
+decompression, gas-consumption, tissue-load, PO₂, ascent-rate, and air-time-remaining record streams. Ordered FIT gas,
+tank-summary, and tank-update records are available separately through `ActivityInterface.getDiveSourceRecords()` and
+remain source-hydration-only rather than native JSON fields. These values follow the FIT profile without record-to-summary
+calculation, interpolation, clamping, gas/tank linking, or gas/tank flattening. Depth,
 average/maximum depth, next-stop depth, and dive-rate display variants follow the first swim-pace preference, using
 meters and meters per second for `/100m` or feet and feet per second for `/100yd`. Dive depths display to three decimal
 places, rates to three, SAC/RMV values to two, and PO₂ retains both FIT decimal places.

--- a/docs/api.ts
+++ b/docs/api.ts
@@ -38,6 +38,24 @@ export type {
 export type { ActivityInterface } from '../src/activities/activity.interface';
 export type { ActivityJSONInterface } from '../src/activities/activity.json.interface';
 /**
+ * Structured FIT gas and tank records are source-hydration data, not numeric
+ * metrics or native-JSON fields. `ActivityInterface.getDiveSourceRecords()`
+ * preserves their source order and parser-decoded units without deriving a
+ * gas-to-tank association or consumption summary.
+ *
+ * @category Activities and events
+ */
+export type {
+  DiveGasMode,
+  DiveGasRecord,
+  DiveGasStatus,
+  DiveMessageIndex,
+  DiveSourceRecords,
+  DiveSourceRecordsInput,
+  DiveTankSummaryRecord,
+  DiveTankUpdateRecord
+} from '../src/activities/dive-source-records';
+/**
  * Canonicalizes unambiguous activity-summary semantics: cadence-shaped stroke-rate summaries
  * become `Stroke Rate`, and homogeneous Diving-group summaries omit terrain metrics.
  *

--- a/docs/guides/importing-activities.md
+++ b/docs/guides/importing-activities.md
@@ -56,6 +56,13 @@ Garmin `single_gas_diving`, `multi_gas_diving`, and `gauge_diving` sub-sports re
 `apnea_diving` and `apnea_hunting` resolve to `Free Diving`. These are direct FIT profile mappings and all remain in the
 Diving activity group.
 
+FIT `dive_gas`, `tank_summary`, and `tank_update` messages are available through
+`activity.getDiveSourceRecords()`. Gas messages are file-level source records and retain source order on each
+Diving-group activity imported from that FIT file. Tank summaries and tank updates are retained only for the activity
+whose session window contains their source timestamp. Oxygen and helium contents are percentages; pressures are bar;
+and volume used is liters. Sports Lib does not infer a gas-to-tank relation, consumption, a gas name, or any missing
+field. These source-hydration records are deliberately not scalar metrics and are not serialized in native JSON.
+
 Diving activities exclude terrain summaries—`Ascent`, `Descent`, altitude min/max/avg, and grade min/max/avg—whether
 they were imported from a FIT summary, restored from native JSON, regenerated into an all-diving event summary, or
 would otherwise be hydrated from streams. Mixed event summaries aggregate terrain values only from non-diving
@@ -99,6 +106,13 @@ in-memory model. Re-serializing that model intentionally omits those values; raw
 Regenerating an event from Diving-group activities now omits those terrain summaries, and a mixed event takes them only
 from its non-diving activities. No source-file reparse is needed; regenerate and reserialize the event summary when an
 application persists regenerated summaries.
+
+### 20.1.0 source-hydrated gas and tank records
+
+FIT imports now expose the parser-provided gas and tank messages through `getDiveSourceRecords()`. Existing native JSON
+does not gain a persisted field and needs no schema migration. An application that wants to show the records for an
+already-stored activity must hydrate them again from its retained original FIT source; Sports Lib does not reconstruct
+them from summary metrics or streams.
 
 Activities expose one-second streams and typed stats. Read numeric values with `getValue()` and display-ready values with
 `getDisplayValue()`. Depth presentation follows the first swim-pace preference: `/100m` selects meters and `/100yd`

--- a/docs/guides/metrics-and-calculations.md
+++ b/docs/guides/metrics-and-calculations.md
@@ -37,7 +37,7 @@ High-level metric domains include:
 - Running/cycling/swim dynamics: ground contact, stance balance, oscillation, ratio, SWOLF, efficiency-related metrics
 - Jump analytics: jump count/events and min/max/avg families for jump height, distance, speed, score, rotations, hang time
 
-Source-native diving metrics
+Source-native diving data
 ---
 FIT imports attach each `dive_summary` to the session or lap identified by its native `reference_mesg` and
 `reference_index`. Message order is irrelevant, lap summaries are never promoted to their activity, and missing summary
@@ -59,7 +59,10 @@ Native record streams are `Depth` and `Next Stop Depth` (`m`), `Next Stop Time`,
 `Volume SAC` and `RMV` (`L/min`), `PO2` (`%`, displayed as `PO₂`), and `Dive Ascent Rate` (`m/s`). These streams retain
 only samples present in the source file: Sports Lib does not fill, smooth, clamp, or derive them. In particular,
 `Air Time Remaining` preserves every non-invalid unsigned FIT value exactly as decoded. Multi-gas and tank messages
-remain structured parser output and are not flattened into scalar statistics.
+are exposed as ordered `ActivityInterface.getDiveSourceRecords()` records: gases retain message-index flags, mixture
+contents, status, and mode; tank summaries retain their timestamps, sensor IDs, pressures, and volume used; and tank
+updates retain their timestamps, sensor IDs, and pressures. They are not flattened into scalar statistics, linked to
+one another, derived into consumption values, or serialized in native JSON.
 
 Presentation preserves the FIT profile precision: depth values and dive rates use three decimal places,
 pressure/volume SAC and RMV use two, and PO₂ uses two rather than the generic one-decimal percentage format. The first

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sports-alliance/sports-lib",
-  "version": "20.0.3",
+  "version": "20.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sports-alliance/sports-lib",
-      "version": "20.0.3",
+      "version": "20.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@googlemaps/polyline-codec": "^1.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sports-alliance/sports-lib",
-  "version": "20.0.3",
+  "version": "20.1.0",
   "description": "A Library to for importing / exporting and processing GPX, TCX, FIT and JSON files from services such as Strava, Movescount, Garmin, Polar etc",
   "keywords": [
     "gpx",

--- a/src/activities/activity.interface.ts
+++ b/src/activities/activity.interface.ts
@@ -17,6 +17,7 @@ import { DataStopAllEvent } from '../data/data.stop-all-event';
 import { DataRiderPositionChangeEvent } from '../data/data.rider-position-change-event';
 import { ActivityParsingOptions } from './activity-parsing-options';
 import { SwimLengthInterface } from '../swim-lengths/swim-length.interface';
+import { DiveSourceRecords, DiveSourceRecordsInput } from './dive-source-records';
 
 /**
  * A recorded activity within an event. Activities own time-indexed streams, metrics, laps,
@@ -216,6 +217,17 @@ export interface ActivityInterface
    * Checks whether the activity has pool swim length rows.
    */
   hasSwimLengths(): boolean;
+
+  /**
+   * Returns source-native FIT dive gas and tank records. These records are
+   * separate from numeric summary stats and streams.
+   */
+  getDiveSourceRecords(): DiveSourceRecords;
+
+  /**
+   * Replaces source-native FIT dive gas and tank records.
+   */
+  setDiveSourceRecords(records: DiveSourceRecordsInput): this;
 
   /**
    * Gets all the timebased events of the activity

--- a/src/activities/activity.spec.ts
+++ b/src/activities/activity.spec.ts
@@ -31,6 +31,61 @@ describe('Activity', () => {
     expect(activity.toJSON().swimLengths).toEqual([]);
   });
 
+  it('keeps source-native dive gas and tank records out of native JSON', () => {
+    const sourceTimestamp = new Date('2026-08-22T10:00:00.000Z');
+    const sourceRecords = {
+      gases: [
+        {
+          messageIndex: { value: 2, reserved: false, selected: true },
+          oxygenContent: 50,
+          status: 'enabled' as const,
+          mode: 'open_circuit' as const
+        }
+      ],
+      tankSummaries: [
+        {
+          timestamp: sourceTimestamp,
+          sensor: 10_001,
+          startPressure: 200,
+          endPressure: 75,
+          volumeUsed: 1396.01
+        }
+      ],
+      tankUpdates: [{ timestamp: sourceTimestamp, sensor: 10_001, pressure: 199 }]
+    };
+
+    activity.setDiveSourceRecords(sourceRecords);
+    sourceRecords.gases[0].oxygenContent = 99;
+    sourceRecords.tankSummaries[0].timestamp.setUTCFullYear(2000);
+
+    const returnedRecords = activity.getDiveSourceRecords();
+    returnedRecords.gases[0].oxygenContent = 88;
+    returnedRecords.gases[0].messageIndex!.value = 8;
+    returnedRecords.tankSummaries[0].timestamp!.setUTCFullYear(1999);
+
+    expect(activity.getDiveSourceRecords()).toEqual({
+      gases: [
+        {
+          messageIndex: { value: 2, reserved: false, selected: true },
+          oxygenContent: 50,
+          status: 'enabled',
+          mode: 'open_circuit'
+        }
+      ],
+      tankSummaries: [
+        {
+          timestamp: new Date('2026-08-22T10:00:00.000Z'),
+          sensor: 10_001,
+          startPressure: 200,
+          endPressure: 75,
+          volumeUsed: 1396.01
+        }
+      ],
+      tankUpdates: [{ timestamp: new Date('2026-08-22T10:00:00.000Z'), sensor: 10_001, pressure: 199 }]
+    });
+    expect(activity.toJSON()).not.toHaveProperty('diveSourceRecords');
+  });
+
   it('should get streams based on time', () => {
     activity.addStream(new Stream(DataAltitude.type, [200, 500, null, 502, null, 600, 700]));
     activity.addStream(new Stream(DataDistance.type, [0, 10, 20, 30, 40, 50, 60]));

--- a/src/activities/activity.ts
+++ b/src/activities/activity.ts
@@ -33,6 +33,7 @@ import { ParsingEventLibError } from '../errors/parsing-event-lib.error';
 import { DurationExceededEventLibError } from '../errors/duration-exceeded-event-lib.error';
 import { SwimLengthInterface } from '../swim-lengths/swim-length.interface';
 import { SwimLengthJSONInterface } from '../swim-lengths/swim-length.json.interface';
+import { cloneDiveSourceRecords, DiveSourceRecords, DiveSourceRecordsInput } from './dive-source-records';
 
 export class Activity extends DurationClassAbstract implements ActivityInterface {
   private static readonly TRAINER_TYPES: ActivityTypes[] = [
@@ -58,6 +59,7 @@ export class Activity extends DurationClassAbstract implements ActivityInterface
   private laps: LapInterface[] = [];
   private swimLengths: SwimLengthInterface[] = [];
   private streams: StreamInterface[] = [];
+  private diveSourceRecords: DiveSourceRecords = cloneDiveSourceRecords();
 
   private events: DataEvent[] = [];
 
@@ -292,6 +294,15 @@ export class Activity extends DurationClassAbstract implements ActivityInterface
 
   hasSwimLengths(): boolean {
     return this.swimLengths.length > 0;
+  }
+
+  getDiveSourceRecords(): DiveSourceRecords {
+    return cloneDiveSourceRecords(this.diveSourceRecords);
+  }
+
+  setDiveSourceRecords(records: DiveSourceRecordsInput): this {
+    this.diveSourceRecords = cloneDiveSourceRecords(records);
+    return this;
   }
 
   getAllEvents(): DataEvent[] {

--- a/src/activities/dive-source-records.ts
+++ b/src/activities/dive-source-records.ts
@@ -1,0 +1,98 @@
+/** FIT `message_index` bits decoded by the FIT parser. */
+export interface DiveMessageIndex {
+  value: number;
+  reserved?: boolean;
+  selected?: boolean;
+}
+
+/** FIT `dive_gas.status` values, including future numeric profile values. */
+export type DiveGasStatus = 'disabled' | 'enabled' | 'backup_only' | number;
+
+/** FIT `dive_gas.mode` values, including future numeric profile values. */
+export type DiveGasMode = 'open_circuit' | 'closed_circuit_diluent' | number;
+
+/**
+ * Source-native FIT dive-gas configuration. Values retain the FIT parser's
+ * decoded units: helium and oxygen contents are percentages.
+ */
+export interface DiveGasRecord {
+  /** FIT `message_index`, including its source flags. */
+  messageIndex?: DiveMessageIndex;
+  /** FIT `helium_content` in percent. */
+  heliumContent?: number;
+  /** FIT `oxygen_content` in percent. */
+  oxygenContent?: number;
+  /** FIT `dive_gas.status` enum value. */
+  status?: DiveGasStatus;
+  /** FIT `dive_gas.mode` enum value. */
+  mode?: DiveGasMode;
+}
+
+/**
+ * Source-native FIT tank summary. Pressures are bar and volume used is litres,
+ * matching the parser's decoded FIT profile values.
+ */
+export interface DiveTankSummaryRecord {
+  /** FIT `tank_summary.timestamp`, when the source provides it. */
+  timestamp?: Date;
+  /** FIT packed ANT channel identifier from `tank_summary.sensor`. */
+  sensor?: number;
+  /** FIT `start_pressure` in bar. */
+  startPressure?: number;
+  /** FIT `end_pressure` in bar. */
+  endPressure?: number;
+  /** FIT `volume_used` in litres. */
+  volumeUsed?: number;
+}
+
+/**
+ * Source-native FIT tank-pressure update. Pressure is bar and timestamp is
+ * retained as decoded by the FIT parser.
+ */
+export interface DiveTankUpdateRecord {
+  /** FIT `tank_update.timestamp`, when the source provides it. */
+  timestamp?: Date;
+  /** FIT packed ANT channel identifier from `tank_update.sensor`. */
+  sensor?: number;
+  /** FIT `pressure` in bar. */
+  pressure?: number;
+}
+
+/**
+ * Raw structured dive records attached to a Diving-group activity during a
+ * source import. They are intentionally separate from numeric stats and
+ * streams: Sports Lib never derives gas mixtures, tank consumption, or a
+ * gas-to-tank association from them. They are source-hydration data and are
+ * deliberately excluded from Sports Lib native JSON serialization.
+ */
+export interface DiveSourceRecords {
+  gases: readonly DiveGasRecord[];
+  tankSummaries: readonly DiveTankSummaryRecord[];
+  tankUpdates: readonly DiveTankUpdateRecord[];
+}
+
+/** Input accepted when replacing an activity's source-native dive records. */
+export type DiveSourceRecordsInput = Partial<DiveSourceRecords>;
+
+export function cloneDiveSourceRecords(records?: DiveSourceRecordsInput | null): DiveSourceRecords {
+  return {
+    gases: Array.isArray(records?.gases)
+      ? records.gases.map(record => ({
+          ...record,
+          ...(record.messageIndex ? { messageIndex: { ...record.messageIndex } } : {})
+        }))
+      : [],
+    tankSummaries: Array.isArray(records?.tankSummaries)
+      ? records.tankSummaries.map(record => ({
+          ...record,
+          ...(record.timestamp ? { timestamp: new Date(record.timestamp.getTime()) } : {})
+        }))
+      : [],
+    tankUpdates: Array.isArray(records?.tankUpdates)
+      ? records.tankUpdates.map(record => ({
+          ...record,
+          ...(record.timestamp ? { timestamp: new Date(record.timestamp.getTime()) } : {})
+        }))
+      : []
+  };
+}

--- a/src/events/adapters/importers/fit/importer.fit.dive.spec.ts
+++ b/src/events/adapters/importers/fit/importer.fit.dive.spec.ts
@@ -66,6 +66,12 @@ const uint32 = (number: number, value: number): FitEncoderField => ({
   baseType: FitBaseType.Uint32,
   value
 });
+const uint32z = (number: number, value: number): FitEncoderField => ({
+  number,
+  size: 4,
+  baseType: FitBaseType.Uint32z,
+  value
+});
 const sint32 = (number: number, value: number): FitEncoderField => ({
   number,
   size: 4,
@@ -253,5 +259,107 @@ describe('EventImporterFIT native diving messages', () => {
 
     expect(activity.getStat(DataDepthAvg.type)?.getValue()).toBe(0.07);
     expect(activity.getStat(DataMetabolicCalories.type)?.getValue()).toBe(159);
+  });
+
+  it('retains multiple source-native gases and tank records without creating a derived summary', async () => {
+    const encoder = new FitEncoder();
+    const start = new Date('2026-08-22T10:00:00.000Z');
+    const startTime = FitEncoder.toFitTimestamp(start);
+    const endTime = startTime + 1_000;
+    const firstTankUpdateTime = startTime + 100;
+
+    encoder.writeMessage(0, [enum8(0, 4), uint16(1, 1), uint32(4, startTime)]);
+    encoder.writeMessage(
+      18,
+      [
+        uint16(254, 0),
+        uint32(253, endTime),
+        uint32(2, startTime),
+        enum8(5, 53),
+        enum8(6, 54),
+        uint32(7, 1_000_000),
+        uint32(8, 1_000_000)
+      ],
+      1
+    );
+    encoder.writeMessage(259, [uint8(0, 0), uint8(1, 21), enum8(2, 1), enum8(3, 0), uint16(254, 0)], 2);
+    encoder.writeMessage(259, [uint8(0, 0), uint8(1, 50), enum8(2, 1), enum8(3, 0), uint16(254, 1)], 2);
+    encoder.writeMessage(259, [uint8(0, 0), uint8(1, 98), enum8(2, 2), enum8(3, 0), uint16(254, 2)], 2);
+    encoder.writeMessage(
+      323,
+      [uint32z(0, 10_001), uint16(1, 20_000), uint16(2, 7_500), uint32(3, 139_601), uint32(253, endTime)],
+      3
+    );
+    encoder.writeMessage(
+      323,
+      [uint32z(0, 10_002), uint16(1, 18_000), uint16(2, 9_500), uint32(3, 88_100), uint32(253, endTime)],
+      3
+    );
+    encoder.writeMessage(319, [uint32z(0, 10_001), uint16(1, 19_900), uint32(253, firstTankUpdateTime)], 4);
+    encoder.writeMessage(319, [uint32z(0, 10_002), uint16(1, 17_900), uint32(253, firstTankUpdateTime + 1)], 4);
+    // A separate session's tank summary must not be assigned to this activity.
+    encoder.writeMessage(
+      323,
+      [uint32z(0, 10_003), uint16(1, 20_000), uint16(2, 10_000), uint32(3, 100_000), uint32(253, endTime + 1)],
+      3
+    );
+
+    const encoded = encoder.close();
+    const event = await EventImporterFIT.getFromArrayBuffer(
+      encoded.buffer.slice(encoded.byteOffset, encoded.byteOffset + encoded.byteLength) as ArrayBuffer
+    );
+    const records = event.getFirstActivity().getDiveSourceRecords();
+
+    expect(records.gases).toEqual([
+      {
+        messageIndex: { value: 0, reserved: false, selected: false },
+        heliumContent: 0,
+        oxygenContent: 21,
+        status: 'enabled',
+        mode: 'open_circuit'
+      },
+      {
+        messageIndex: { value: 1, reserved: false, selected: false },
+        heliumContent: 0,
+        oxygenContent: 50,
+        status: 'enabled',
+        mode: 'open_circuit'
+      },
+      {
+        messageIndex: { value: 2, reserved: false, selected: false },
+        heliumContent: 0,
+        oxygenContent: 98,
+        status: 'backup_only',
+        mode: 'open_circuit'
+      }
+    ]);
+    expect(records.tankSummaries).toEqual([
+      {
+        sensor: 10_001,
+        startPressure: 200,
+        endPressure: 75,
+        volumeUsed: 1396.01,
+        timestamp: new Date(start.getTime() + 1_000_000)
+      },
+      {
+        sensor: 10_002,
+        startPressure: 180,
+        endPressure: 95,
+        volumeUsed: 881,
+        timestamp: new Date(start.getTime() + 1_000_000)
+      }
+    ]);
+    expect(records.tankUpdates).toEqual([
+      {
+        sensor: 10_001,
+        pressure: 199,
+        timestamp: new Date(start.getTime() + 100_000)
+      },
+      {
+        sensor: 10_002,
+        pressure: 179,
+        timestamp: new Date(start.getTime() + 101_000)
+      }
+    ]);
   });
 });

--- a/src/events/adapters/importers/fit/importer.fit.ts
+++ b/src/events/adapters/importers/fit/importer.fit.ts
@@ -4,7 +4,20 @@ import { SwimLength } from '../../../../swim-lengths/swim-length';
 import { Lap } from '../../../../laps/lap';
 import { EventInterface } from '../../../event.interface';
 import { CreatorInterface } from '../../../../creators/creator.interface';
-import { ActivityTypes, ActivityTypesHelper, ActivityTypesMoving } from '../../../../activities/activity.types';
+import {
+  ActivityTypeGroups,
+  ActivityTypes,
+  ActivityTypesHelper,
+  ActivityTypesMoving
+} from '../../../../activities/activity.types';
+import {
+  DiveGasMode,
+  DiveGasRecord,
+  DiveGasStatus,
+  DiveMessageIndex,
+  DiveTankSummaryRecord,
+  DiveTankUpdateRecord
+} from '../../../../activities/dive-source-records';
 import { DataDuration } from '../../../../data/data.duration';
 import { DataElapsedTime } from '../../../../data/data.elapsed-time';
 import { DataEnergy } from '../../../../data/data.energy';
@@ -337,6 +350,7 @@ export class EventImporterFIT {
           // Get the activity from the sessionObject
           const activity = this.getActivityFromSessionObject(sessionObject, fitDataObject, options, sessionIndex);
           this.addDiveSummaryStats(activity, this.getReferencedDiveSummary(fitDataObject, 'session', sessionObject));
+          this.addDiveSourceRecords(activity, fitDataObject);
           // Go over the laps
           sessionObject.laps.forEach((sessionLapObject: any, index: number) => {
             const lap = this.getLapFromSessionLapObject(sessionLapObject, activity, index, options);
@@ -854,6 +868,177 @@ export class EventImporterFIT {
     }
 
     return null;
+  }
+
+  /**
+   * Keeps FIT gas and tank messages as structured source records. They do not
+   * become scalar stats and no relation between a gas and a tank is inferred.
+   */
+  private static addDiveSourceRecords(
+    activity: ActivityInterface,
+    fitDataObject: { dive_gases?: unknown; tank_summaries?: unknown; tank_updates?: unknown }
+  ): void {
+    if (ActivityTypesHelper.getActivityGroupForActivityType(activity.type) !== ActivityTypeGroups.DivingGroup) {
+      return;
+    }
+
+    activity.setDiveSourceRecords({
+      gases: this.getDiveGasRecords(fitDataObject?.dive_gases),
+      tankSummaries: this.getDiveTankSummariesForActivity(fitDataObject?.tank_summaries, activity),
+      tankUpdates: this.getDiveTankUpdatesForActivity(fitDataObject?.tank_updates, activity)
+    });
+  }
+
+  private static getDiveGasRecords(records: unknown): DiveGasRecord[] {
+    if (!Array.isArray(records)) {
+      return [];
+    }
+
+    return records
+      .filter((record: unknown): record is Record<string, unknown> => !!record && typeof record === 'object')
+      .map(record => {
+        const mappedRecord: DiveGasRecord = {};
+        const messageIndex = this.getDiveMessageIndex(record.message_index);
+        const heliumContent = this.getNumericValue(record.helium_content);
+        const oxygenContent = this.getNumericValue(record.oxygen_content);
+        const status = this.getDiveGasStatus(record.status);
+        const mode = this.getDiveGasMode(record.mode);
+
+        if (messageIndex) {
+          mappedRecord.messageIndex = messageIndex;
+        }
+        if (heliumContent !== null) {
+          mappedRecord.heliumContent = heliumContent;
+        }
+        if (oxygenContent !== null) {
+          mappedRecord.oxygenContent = oxygenContent;
+        }
+        if (status !== null) {
+          mappedRecord.status = status;
+        }
+        if (mode !== null) {
+          mappedRecord.mode = mode;
+        }
+
+        return mappedRecord;
+      });
+  }
+
+  private static getDiveTankSummariesForActivity(
+    records: unknown,
+    activity: ActivityInterface
+  ): DiveTankSummaryRecord[] {
+    if (!Array.isArray(records)) {
+      return [];
+    }
+
+    return records
+      .filter((record: unknown): record is Record<string, unknown> => this.isDiveRecordWithinActivity(record, activity))
+      .map(record => {
+        const mappedRecord: DiveTankSummaryRecord = {
+          timestamp: this.getDateFromValue(record.timestamp)!
+        };
+        const sensor = this.getNumericValue(record.sensor);
+        const startPressure = this.getNumericValue(record.start_pressure);
+        const endPressure = this.getNumericValue(record.end_pressure);
+        const volumeUsed = this.getNumericValue(record.volume_used);
+
+        if (sensor !== null) {
+          mappedRecord.sensor = sensor;
+        }
+        if (startPressure !== null) {
+          mappedRecord.startPressure = startPressure;
+        }
+        if (endPressure !== null) {
+          mappedRecord.endPressure = endPressure;
+        }
+        if (volumeUsed !== null) {
+          mappedRecord.volumeUsed = volumeUsed;
+        }
+
+        return mappedRecord;
+      });
+  }
+
+  private static getDiveTankUpdatesForActivity(records: unknown, activity: ActivityInterface): DiveTankUpdateRecord[] {
+    if (!Array.isArray(records)) {
+      return [];
+    }
+
+    return records
+      .filter((record: unknown): record is Record<string, unknown> => this.isDiveRecordWithinActivity(record, activity))
+      .map(record => {
+        const mappedRecord: DiveTankUpdateRecord = {
+          timestamp: this.getDateFromValue(record.timestamp)!
+        };
+        const sensor = this.getNumericValue(record.sensor);
+        const pressure = this.getNumericValue(record.pressure);
+
+        if (sensor !== null) {
+          mappedRecord.sensor = sensor;
+        }
+        if (pressure !== null) {
+          mappedRecord.pressure = pressure;
+        }
+
+        return mappedRecord;
+      });
+  }
+
+  private static isDiveRecordWithinActivity(
+    record: unknown,
+    activity: ActivityInterface
+  ): record is Record<string, unknown> {
+    if (!record || typeof record !== 'object') {
+      return false;
+    }
+
+    const timestamp = this.getDateFromValue((record as { timestamp?: unknown }).timestamp);
+    return (
+      !!timestamp &&
+      timestamp.getTime() >= activity.startDate.getTime() &&
+      timestamp.getTime() <= activity.endDate.getTime()
+    );
+  }
+
+  private static getDiveMessageIndex(value: unknown): DiveMessageIndex | null {
+    if (!value || typeof value !== 'object') {
+      return null;
+    }
+
+    const sourceValue = value as { value?: unknown; reserved?: unknown; selected?: unknown };
+    const messageIndex = this.getNumericValue(sourceValue.value);
+    if (messageIndex === null || !Number.isInteger(messageIndex)) {
+      return null;
+    }
+
+    const mappedIndex: DiveMessageIndex = { value: messageIndex };
+    if (typeof sourceValue.reserved === 'boolean') {
+      mappedIndex.reserved = sourceValue.reserved;
+    }
+    if (typeof sourceValue.selected === 'boolean') {
+      mappedIndex.selected = sourceValue.selected;
+    }
+
+    return mappedIndex;
+  }
+
+  private static getDiveGasStatus(value: unknown): DiveGasStatus | null {
+    if (value === 'disabled' || value === 'enabled' || value === 'backup_only') {
+      return value;
+    }
+
+    const numericValue = this.getNumericValue(value);
+    return numericValue !== null && Number.isInteger(numericValue) ? numericValue : null;
+  }
+
+  private static getDiveGasMode(value: unknown): DiveGasMode | null {
+    if (value === 'open_circuit' || value === 'closed_circuit_diluent') {
+      return value;
+    }
+
+    const numericValue = this.getNumericValue(value);
+    return numericValue !== null && Number.isInteger(numericValue) ? numericValue : null;
   }
 
   private static getReferencedDiveSummary(

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,16 @@ export { normalizeActivityMetricSemanticsForStats } from './activities/activity.
 export * from './activities/activity-parsing-options';
 export * from './activities/activity.json.interface';
 export * from './activities/activity.types';
+export type {
+  DiveGasMode,
+  DiveGasRecord,
+  DiveGasStatus,
+  DiveMessageIndex,
+  DiveSourceRecords,
+  DiveSourceRecordsInput,
+  DiveTankSummaryRecord,
+  DiveTankUpdateRecord
+} from './activities/dive-source-records';
 export * from './activities/devices/device.interface';
 export * from './activities/devices/device.json.interface';
 export * from './constants/constants';


### PR DESCRIPTION
## Summary

- Add typed source-native FIT gas, tank-summary, and tank-update records to `ActivityInterface.getDiveSourceRecords()`.
- Preserve FIT source order, decoded values and units without deriving gas names, consumption, gas-to-tank links, or scalar metrics.
- Keep the records source-hydration-only: they are intentionally excluded from Sports Lib native JSON.
- Bump Sports Lib to `20.1.0` and document the source-hydration migration.

## Validation

- `npm test -- --runInBand` — 105 suites / 1,869 passing tests
- `npm run build`
- `npm run docs:build`
- Parsed the real Garmin Descent Mk3i multi-gas fixture: 3 gases, 1 tank summary, and 1,172 tank updates retained exactly.

## Release note

This additive API is the prerequisite for Quantified Self to hydrate a source-native Gas & Tanks section in its Diving tab. No native JSON migration or historical reparse is required.
