### PR TITLE
feat: classify fallback sports into activity groups

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,10 @@ Activity-aware cadence semantics produce stroke rate for swimming, rowing, and p
 summaries separately from activities can explicitly canonicalize those projections with
 `normalizeActivityMetricSemanticsForStats` after determining the contributing activity types.
 
+Activity groups distinguish generic and inline skating from Ice Skating, retain flight altitude metrics with vertical
+speed for aerial activities, and classify motorized and adaptive-mobility activities without deriving training stress or
+durability evidence.
+
 FIT imports retain parser-scaled record depth samples in canonical meters and native session/lap dive summaries plus
 decompression, gas-consumption, tissue-load, PO₂, ascent-rate, and air-time-remaining record streams. Ordered FIT gas,
 tank-summary, and tank-update records are available separately through `ActivityInterface.getDiveSourceRecords()` and

--- a/docs/api.ts
+++ b/docs/api.ts
@@ -68,9 +68,11 @@ export type {
  */
 export { normalizeActivityMetricSemanticsForStats } from '../src/activities/activity.metric-semantics';
 /**
- * Canonical activity types, activity groups, and alias resolution. Snorkeling and Mermaiding
- * are canonical diving activities. `ActivityTypesHelper` excludes all Diving-group activities
- * from terrain elevation and grade summaries while preserving their raw source streams.
+ * Canonical activity types, activity groups, and alias resolution. `Skating` and `Inline Skating`
+ * belong to `skating_group`, while `Ice Skating` remains a winter sport. Aerial activities expose
+ * vertical-speed derivation; Motorized and Adaptive Mobility activities do not receive calculated
+ * TSS or durability, but preserve source-imported TSS. Snorkeling and Mermaiding are canonical
+ * diving activities, whose terrain summaries are excluded while raw source streams remain available.
  *
  * @category Activities and events
  */

--- a/docs/guides/importing-activities.md
+++ b/docs/guides/importing-activities.md
@@ -12,6 +12,11 @@ activities. For example, `snorkeling` resolves to `Snorkeling`; `Mermaiding` is 
 when a provider supplies that sport name. A provider-specific numeric FIT mapping is added only when the FIT
 profile or a representative file establishes one.
 
+Canonical activity types also receive a stable activity group. `Skating` and `Inline Skating` belong to the dedicated
+Skating group, while `Ice Skating` remains in Winter Sports. Aerial activities retain altitude, ascent, and descent
+while exposing vertical speed. Motorized and Adaptive Mobility activities retain movement data but do not receive
+library-calculated Training Stress Score or durability evidence; a source-provided Training Stress Score remains intact.
+
 ```sh
 npm install @sports-alliance/sports-lib @xmldom/xmldom
 ```

--- a/docs/guides/metrics-and-calculations.md
+++ b/docs/guides/metrics-and-calculations.md
@@ -358,6 +358,10 @@ Priority order:
 
 - POWER -> HR -> PACE/SWIM_PACE -> MET
 
+Motorized and Adaptive Mobility activities do not receive library-calculated TSS, even when calculation inputs are
+available. A source-provided TSS remains available and is labeled `IMPORTED`; no durability evidence is generated for
+either group.
+
 POWER TSS:
 
 ```text

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sports-alliance/sports-lib",
-  "version": "20.1.1",
+  "version": "20.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sports-alliance/sports-lib",
-      "version": "20.1.1",
+      "version": "20.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@googlemaps/polyline-codec": "^1.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sports-alliance/sports-lib",
-  "version": "20.1.1",
+  "version": "20.2.0",
   "description": "A Library to for importing / exporting and processing GPX, TCX, FIT and JSON files from services such as Strava, Movescount, Garmin, Polar etc",
   "keywords": [
     "gpx",

--- a/src/activities/activity.types.ts
+++ b/src/activities/activity.types.ts
@@ -66,9 +66,7 @@ export class ActivityTypesHelper {
   }
 
   static getActivityTypeGroupsAsUniqueArray(): ActivityTypeGroup[] {
-    const activityTypeGroups = Array.from(
-      new Set(Object.values(ActivityTypeGroups))
-    ) as ActivityTypeGroup[];
+    const activityTypeGroups = Array.from(new Set(Object.values(ActivityTypeGroups))) as ActivityTypeGroup[];
 
     return activityTypeGroups.sort((left, right) => {
       if (left < right) {
@@ -136,6 +134,7 @@ export class ActivityTypesHelper {
       case ActivityTypeGroups.MountainBikingGroup:
       case ActivityTypeGroups.OutdoorAdventuresGroup:
       case ActivityTypeGroups.PerformanceGroup:
+      case ActivityTypeGroups.AerialSportsGroup:
         return [DataVerticalSpeed.type];
       default:
         return [];
@@ -189,8 +188,11 @@ export class ActivityTypesHelper {
    * This function can also be called: Fighting with a non functional language
    */
   static getActivityGroupForActivityType(activityType: ActivityTypes): ActivityTypeGroup {
-    return (Object.entries(ActivityTypesGroupMapping.map) as Array<[ActivityTypeGroup, ActivityTypes[]]>)
-      .find(([, activityTypes]) => activityTypes.includes(activityType))?.[0] || ActivityTypeGroups.UnspecifiedGroup;
+    return (
+      (Object.entries(ActivityTypesGroupMapping.map) as Array<[ActivityTypeGroup, ActivityTypes[]]>).find(
+        ([, activityTypes]) => activityTypes.includes(activityType)
+      )?.[0] || ActivityTypeGroups.UnspecifiedGroup
+    );
   }
 
   static isIndoorActivityType(activityType: ActivityTypes): boolean {
@@ -1088,13 +1090,17 @@ export const ActivityTypeGroups = {
   IndoorSportsGroup: 'indoor_sports_group',
   OutdoorAdventuresGroup: 'outdoor_adventures_group',
   WinterSportsGroup: 'winter_sports_group',
+  SkatingGroup: 'skating_group',
+  AerialSportsGroup: 'aerial_sports_group',
+  MotorizedGroup: 'motorized_group',
+  AdaptiveMobilityGroup: 'adaptive_mobility_group',
   WaterSportsGroup: 'water_sports_group',
   DivingGroup: 'diving_group',
   TeamRacketGroup: 'team_racket_group',
-  UnspecifiedGroup: 'unspecified_group',
+  UnspecifiedGroup: 'unspecified_group'
 } as const;
 
-export type ActivityTypeGroup = typeof ActivityTypeGroups[keyof typeof ActivityTypeGroups];
+export type ActivityTypeGroup = (typeof ActivityTypeGroups)[keyof typeof ActivityTypeGroups];
 
 export class ActivityTypesGroupMapping {
   public static readonly map: Record<ActivityTypeGroup, ActivityTypes[]> = {
@@ -1104,32 +1110,33 @@ export class ActivityTypesGroupMapping {
       ActivityTypes.IndoorRunning,
       ActivityTypes.VirtualRunning
     ],
-    [ActivityTypeGroups.TrailRunningGroup]: [
-      ActivityTypes.TrailRunning
-    ],
+    [ActivityTypeGroups.TrailRunningGroup]: [ActivityTypes.TrailRunning],
     [ActivityTypeGroups.CyclingGroup]: [
       ActivityTypes.Cycling,
       ActivityTypes.IndoorCycling,
       ActivityTypes.Biking,
       ActivityTypes.VirtualCycling,
-      ActivityTypes.EBiking
+      ActivityTypes.EBiking,
+      ActivityTypes.Handcycle,
+      ActivityTypes.Velomobile
     ],
     [ActivityTypeGroups.MountainBikingGroup]: [
       ActivityTypes.MountainBiking,
       ActivityTypes['Enduro MTB'],
       ActivityTypes.DownhillCycling
     ],
-    [ActivityTypeGroups.SwimmingGroup]: [
-      ActivityTypes.Swimming,
-      ActivityTypes.OpenWaterSwimming
-    ],
+    [ActivityTypeGroups.SwimmingGroup]: [ActivityTypes.Swimming, ActivityTypes.OpenWaterSwimming],
     [ActivityTypeGroups.PerformanceGroup]: [
       ActivityTypes.Crossfit,
       ActivityTypes.Orienteering,
       ActivityTypes.RollerSki,
       ActivityTypes.TrackAndField,
       ActivityTypes.Triathlon,
-      ActivityTypes.Multisport
+      ActivityTypes.Multisport,
+      ActivityTypes['Adventure Racing'],
+      ActivityTypes.Aquathlon,
+      ActivityTypes.Duathlon,
+      ActivityTypes.Swimrun
     ],
     [ActivityTypeGroups.IndoorSportsGroup]: [
       ActivityTypes.Gymnastics,
@@ -1143,7 +1150,19 @@ export class ActivityTypesGroupMapping {
       ActivityTypes.WeightTraining,
       ActivityTypes.StrengthTraining,
       ActivityTypes.Training,
-      ActivityTypes.FlexibilityTraining
+      ActivityTypes.FlexibilityTraining,
+      ActivityTypes.FitnessEquipment,
+      ActivityTypes.Aerobics,
+      ActivityTypes.Boxing,
+      ActivityTypes.CardioTraining,
+      ActivityTypes.Cheerleading,
+      ActivityTypes['Circuit Training'],
+      ActivityTypes.Combat,
+      ActivityTypes.EllipticalTrainer,
+      ActivityTypes.HIIT,
+      ActivityTypes.IndoorTraining,
+      ActivityTypes.Pilates,
+      ActivityTypes.StairStepper
     ],
     [ActivityTypeGroups.OutdoorAdventuresGroup]: [
       ActivityTypes.Walking,
@@ -1155,7 +1174,12 @@ export class ActivityTypesGroupMapping {
       ActivityTypes['Indoor Climbing'],
       ActivityTypes.Bouldering,
       ActivityTypes.Canyoning,
-      ActivityTypes.ViaFerrata
+      ActivityTypes.ViaFerrata,
+      ActivityTypes.Fishing,
+      ActivityTypes.FloorClimbing,
+      ActivityTypes.Hunting,
+      ActivityTypes.Mountaineering,
+      ActivityTypes.Trekking
     ],
     [ActivityTypeGroups.WinterSportsGroup]: [
       ActivityTypes.CrosscountrySkiing,
@@ -1169,6 +1193,22 @@ export class ActivityTypesGroupMapping {
       ActivityTypes.BackCountrySki,
       ActivityTypes.NordicSki
     ],
+    [ActivityTypeGroups.SkatingGroup]: [ActivityTypes.InlineSkating, ActivityTypes.Skating],
+    [ActivityTypeGroups.AerialSportsGroup]: [
+      ActivityTypes.Flying,
+      ActivityTypes.HangGliding,
+      ActivityTypes.Jumpmaster,
+      ActivityTypes.Paragliding,
+      ActivityTypes.SkyDiving
+    ],
+    [ActivityTypeGroups.MotorizedGroup]: [
+      ActivityTypes.Boating,
+      ActivityTypes.Driving,
+      ActivityTypes.Motorcycling,
+      ActivityTypes.Motorsports,
+      ActivityTypes.Snowmobiling
+    ],
+    [ActivityTypeGroups.AdaptiveMobilityGroup]: [ActivityTypes.Wheelchair],
     [ActivityTypeGroups.WaterSportsGroup]: [
       ActivityTypes.Rowing,
       ActivityTypes.Surfing,
@@ -1178,7 +1218,10 @@ export class ActivityTypesGroupMapping {
       ActivityTypes.Canoeing,
       ActivityTypes.Kayaking,
       ActivityTypes.Paddling,
-      ActivityTypes.StandUpPaddling
+      ActivityTypes.StandUpPaddling,
+      ActivityTypes.Rafting,
+      ActivityTypes.WaterSkiing,
+      ActivityTypes.Windsurfing
     ],
     [ActivityTypeGroups.DivingGroup]: [
       ActivityTypes.Diving,
@@ -1202,9 +1245,13 @@ export class ActivityTypesGroupMapping {
       ActivityTypes.Squash,
       ActivityTypes.RacquetBall,
       ActivityTypes.TableTennis,
-      ActivityTypes.Tennis
+      ActivityTypes.Tennis,
+      ActivityTypes.Cricket,
+      ActivityTypes.Frisbee,
+      ActivityTypes.Soccer,
+      ActivityTypes.Volleyball
     ],
-    [ActivityTypeGroups.UnspecifiedGroup]: [],
+    [ActivityTypeGroups.UnspecifiedGroup]: []
   };
 }
 

--- a/src/activities/activityt-types.spec.ts
+++ b/src/activities/activityt-types.spec.ts
@@ -2,14 +2,76 @@ import { DataPaceAvg } from '../data/data.pace-avg';
 import { DataPace } from '../data/data.pace';
 import { DataSpeedAvg } from '../data/data.speed-avg';
 import { DataSpeed } from '../data/data.speed';
-import { ActivityTypeGroups, ActivityTypes, ActivityTypesHelper } from './activity.types';
+import { DataVerticalSpeed } from '../data/data.vertical-speed';
+import { ActivityTypeGroups, ActivityTypes, ActivityTypesHelper, ActivityTypesMoving } from './activity.types';
+
+const proposedGroupAssignments = [
+  [ActivityTypes.Aerobics, ActivityTypeGroups.IndoorSportsGroup],
+  [ActivityTypes.Boxing, ActivityTypeGroups.IndoorSportsGroup],
+  [ActivityTypes.CardioTraining, ActivityTypeGroups.IndoorSportsGroup],
+  [ActivityTypes.Cheerleading, ActivityTypeGroups.IndoorSportsGroup],
+  [ActivityTypes['Circuit Training'], ActivityTypeGroups.IndoorSportsGroup],
+  [ActivityTypes.Combat, ActivityTypeGroups.IndoorSportsGroup],
+  [ActivityTypes.EllipticalTrainer, ActivityTypeGroups.IndoorSportsGroup],
+  [ActivityTypes.FitnessEquipment, ActivityTypeGroups.IndoorSportsGroup],
+  [ActivityTypes.HIIT, ActivityTypeGroups.IndoorSportsGroup],
+  [ActivityTypes.IndoorTraining, ActivityTypeGroups.IndoorSportsGroup],
+  [ActivityTypes.Pilates, ActivityTypeGroups.IndoorSportsGroup],
+  [ActivityTypes.StairStepper, ActivityTypeGroups.IndoorSportsGroup],
+  [ActivityTypes['Adventure Racing'], ActivityTypeGroups.PerformanceGroup],
+  [ActivityTypes.Aquathlon, ActivityTypeGroups.PerformanceGroup],
+  [ActivityTypes.Duathlon, ActivityTypeGroups.PerformanceGroup],
+  [ActivityTypes.Swimrun, ActivityTypeGroups.PerformanceGroup],
+  [ActivityTypes.Fishing, ActivityTypeGroups.OutdoorAdventuresGroup],
+  [ActivityTypes.FloorClimbing, ActivityTypeGroups.OutdoorAdventuresGroup],
+  [ActivityTypes.Hunting, ActivityTypeGroups.OutdoorAdventuresGroup],
+  [ActivityTypes.Mountaineering, ActivityTypeGroups.OutdoorAdventuresGroup],
+  [ActivityTypes.Trekking, ActivityTypeGroups.OutdoorAdventuresGroup],
+  [ActivityTypes.Handcycle, ActivityTypeGroups.CyclingGroup],
+  [ActivityTypes.Velomobile, ActivityTypeGroups.CyclingGroup],
+  [ActivityTypes.Rafting, ActivityTypeGroups.WaterSportsGroup],
+  [ActivityTypes.WaterSkiing, ActivityTypeGroups.WaterSportsGroup],
+  [ActivityTypes.Windsurfing, ActivityTypeGroups.WaterSportsGroup],
+  [ActivityTypes.Cricket, ActivityTypeGroups.TeamRacketGroup],
+  [ActivityTypes.Frisbee, ActivityTypeGroups.TeamRacketGroup],
+  [ActivityTypes.Soccer, ActivityTypeGroups.TeamRacketGroup],
+  [ActivityTypes.Volleyball, ActivityTypeGroups.TeamRacketGroup],
+  [ActivityTypes.InlineSkating, ActivityTypeGroups.SkatingGroup],
+  [ActivityTypes.Skating, ActivityTypeGroups.SkatingGroup],
+  [ActivityTypes.Flying, ActivityTypeGroups.AerialSportsGroup],
+  [ActivityTypes.HangGliding, ActivityTypeGroups.AerialSportsGroup],
+  [ActivityTypes.Jumpmaster, ActivityTypeGroups.AerialSportsGroup],
+  [ActivityTypes.Paragliding, ActivityTypeGroups.AerialSportsGroup],
+  [ActivityTypes.SkyDiving, ActivityTypeGroups.AerialSportsGroup],
+  [ActivityTypes.Boating, ActivityTypeGroups.MotorizedGroup],
+  [ActivityTypes.Driving, ActivityTypeGroups.MotorizedGroup],
+  [ActivityTypes.Motorcycling, ActivityTypeGroups.MotorizedGroup],
+  [ActivityTypes.Motorsports, ActivityTypeGroups.MotorizedGroup],
+  [ActivityTypes.Snowmobiling, ActivityTypeGroups.MotorizedGroup],
+  [ActivityTypes.Wheelchair, ActivityTypeGroups.AdaptiveMobilityGroup]
+] as const;
+
+const intentionalUnspecifiedActivityTypes = [
+  ActivityTypes.Generic,
+  ActivityTypes.Match,
+  ActivityTypes.Other,
+  ActivityTypes.Route,
+  ActivityTypes.Tactical,
+  ActivityTypes.Transition,
+  ActivityTypes.UnknownSport,
+  ActivityTypes.Workout
+].sort();
 
 describe('ActivityTypes', () => {
   beforeEach(() => {});
 
   it('get the correct activity group', () => {
-    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Running)).toBe(ActivityTypeGroups.RunningGroup);
-    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Cycling)).toBe(ActivityTypeGroups.CyclingGroup);
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Running)).toBe(
+      ActivityTypeGroups.RunningGroup
+    );
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Cycling)).toBe(
+      ActivityTypeGroups.CyclingGroup
+    );
     expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.MountainBiking)).toBe(
       ActivityTypeGroups.MountainBikingGroup
     );
@@ -34,24 +96,55 @@ describe('ActivityTypes', () => {
     expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Wakeboarding)).toBe(
       ActivityTypeGroups.WaterSportsGroup
     );
-    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Diving)).toBe(ActivityTypeGroups.DivingGroup);
-    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Snorkeling)).toBe(ActivityTypeGroups.DivingGroup);
-    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Mermaiding)).toBe(ActivityTypeGroups.DivingGroup);
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Diving)).toBe(
+      ActivityTypeGroups.DivingGroup
+    );
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Snorkeling)).toBe(
+      ActivityTypeGroups.DivingGroup
+    );
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Mermaiding)).toBe(
+      ActivityTypeGroups.DivingGroup
+    );
     expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Tennis)).toBe(
       ActivityTypeGroups.TeamRacketGroup
+    );
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.IceSkating)).toBe(
+      ActivityTypeGroups.WinterSportsGroup
     );
     expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.Workout)).toBe(
       ActivityTypeGroups.UnspecifiedGroup
     );
     expect(ActivityTypesHelper.getActivityGroupForActivityType(ActivityTypes.HIIT)).toBe(
-      ActivityTypeGroups.UnspecifiedGroup
+      ActivityTypeGroups.IndoorSportsGroup
     );
+  });
+
+  it.each(proposedGroupAssignments)('assigns %s to %s', (activityType, activityGroup) => {
+    expect(ActivityTypesHelper.getActivityGroupForActivityType(activityType)).toBe(activityGroup);
+  });
+
+  it('keeps only generic and structural labels unspecified', () => {
+    const unspecifiedActivityTypes = ActivityTypesHelper.getActivityTypesAsUniqueArray().filter(
+      activityType =>
+        ActivityTypesHelper.getActivityGroupForActivityType(activityType as ActivityTypes) ===
+        ActivityTypeGroups.UnspecifiedGroup
+    );
+
+    expect(unspecifiedActivityTypes).toEqual(intentionalUnspecifiedActivityTypes);
   });
 
   it('exposes canonical group ids and members', () => {
     expect(ActivityTypesHelper.getActivityTypeGroupsAsUniqueArray()).toContain(ActivityTypeGroups.WaterSportsGroup);
     expect(ActivityTypeGroups.WaterSportsGroup).toBe('water_sports_group');
-    expect(ActivityTypesHelper.getActivityTypesForActivityGroup(ActivityTypeGroups.WaterSportsGroup)).toContain(ActivityTypes.Kayaking);
+    expect(ActivityTypesHelper.getActivityTypesForActivityGroup(ActivityTypeGroups.WaterSportsGroup)).toContain(
+      ActivityTypes.Kayaking
+    );
+    expect(ActivityTypesHelper.getActivityTypeGroupsAsUniqueArray()).toContain(ActivityTypeGroups.SkatingGroup);
+    expect(ActivityTypeGroups.SkatingGroup).toBe('skating_group');
+    expect(ActivityTypesHelper.getActivityTypesForActivityGroup(ActivityTypeGroups.SkatingGroup)).toEqual([
+      ActivityTypes.InlineSkating,
+      ActivityTypes.Skating
+    ]);
   });
 
   it('should identify indoor activity types across indoor labels and indoor-group members', () => {
@@ -61,8 +154,42 @@ describe('ActivityTypes', () => {
     expect(ActivityTypesHelper.isIndoorActivityType(ActivityTypes.IndoorClimbing)).toBe(true);
     expect(ActivityTypesHelper.isIndoorActivityType(ActivityTypes.Yoga)).toBe(true);
     expect(ActivityTypesHelper.isIndoorActivityType(ActivityTypes.Treadmill)).toBe(true);
+    expect(ActivityTypesHelper.isIndoorActivityType(ActivityTypes.FitnessEquipment)).toBe(true);
     expect(ActivityTypesHelper.isIndoorActivityType(ActivityTypes.Cycling)).toBe(false);
     expect(ActivityTypesHelper.isIndoorActivityType(ActivityTypes.Running)).toBe(false);
+  });
+
+  it('applies the agreed family-specific metric behavior', () => {
+    expect(ActivityTypesHelper.verticalSpeedDerivedDataTypesToUseForActivityType(ActivityTypes.Flying)).toEqual([
+      DataVerticalSpeed.type
+    ]);
+    expect(ActivityTypesHelper.speedDerivedDataTypesToUseForActivityType(ActivityTypes.Flying)).toEqual([
+      DataSpeed.type
+    ]);
+    expect(ActivityTypesHelper.averageSpeedDerivedDataTypesToUseForActivityType(ActivityTypes.Flying)).toEqual([
+      DataSpeedAvg.type
+    ]);
+    expect(ActivityTypesHelper.altiDistanceSpeedDerivedDataTypesToUseForActivityType(ActivityTypes.Flying)).toEqual([]);
+    expect(ActivityTypesHelper.shouldExcludeTerrainSummaryMetrics(ActivityTypes.Flying)).toBe(false);
+
+    [
+      ActivityTypes.InlineSkating,
+      ActivityTypes.Skating,
+      ActivityTypes.Flying,
+      ActivityTypes.Driving,
+      ActivityTypes.Wheelchair
+    ].forEach(activityType => {
+      expect(ActivityTypesMoving.getSpeedThreshold(activityType)).toBe(0.3);
+    });
+
+    [ActivityTypes.InlineSkating, ActivityTypes.Driving, ActivityTypes.Wheelchair].forEach(activityType => {
+      expect(ActivityTypesHelper.speedDerivedDataTypesToUseForActivityType(activityType)).toEqual([DataSpeed.type]);
+      expect(ActivityTypesHelper.averageSpeedDerivedDataTypesToUseForActivityType(activityType)).toEqual([
+        DataSpeedAvg.type
+      ]);
+      expect(ActivityTypesHelper.verticalSpeedDerivedDataTypesToUseForActivityType(activityType)).toEqual([]);
+      expect(ActivityTypesHelper.altiDistanceSpeedDerivedDataTypesToUseForActivityType(activityType)).toEqual([]);
+    });
   });
 
   it('should map alpine_skiing_downhill to AlpineSkiing', () => {
@@ -131,7 +258,7 @@ describe('ActivityTypes', () => {
         ActivityTypes.FreeDiving,
         ActivityTypes.Snorkeling,
         ActivityTypes.Mermaiding
-      ].forEach((activityType) => {
+      ].forEach(activityType => {
         expect(ActivityTypesHelper.shouldExcludeAscent(activityType)).toBe(true);
       });
     });
@@ -175,7 +302,7 @@ describe('ActivityTypes', () => {
         ActivityTypes.FreeDiving,
         ActivityTypes.Snorkeling,
         ActivityTypes.Mermaiding
-      ].forEach((activityType) => {
+      ].forEach(activityType => {
         expect(ActivityTypesHelper.shouldExcludeDescent(activityType)).toBe(true);
       });
     });

--- a/src/data/data.three-dimensional-strain-evidence.spec.ts
+++ b/src/data/data.three-dimensional-strain-evidence.spec.ts
@@ -1,4 +1,4 @@
-import { ActivityTypes, ActivityTypesHelper } from '../activities/activity.types';
+import { ActivityTypeGroups, ActivityTypes, ActivityTypesHelper } from '../activities/activity.types';
 import {
   DataThreeDimensionalStrainEvidence,
   THREE_DIMENSIONAL_STRAIN_LEGACY_PROTOCOL_VERSION,
@@ -70,6 +70,25 @@ describe('DataThreeDimensionalStrainEvidence legacy compatibility', () => {
     };
 
     expect(normalizeThreeDimensionalStrainEvidenceValue(legacy)).toEqual(legacy);
+  });
+
+  it.each([
+    [ActivityTypes.InlineSkating, ActivityTypeGroups.SkatingGroup],
+    [ActivityTypes.Flying, ActivityTypeGroups.AerialSportsGroup],
+    [ActivityTypes.Driving, ActivityTypeGroups.MotorizedGroup],
+    [ActivityTypes.Wheelchair, ActivityTypeGroups.AdaptiveMobilityGroup],
+    [ActivityTypes.FitnessEquipment, ActivityTypeGroups.IndoorSportsGroup]
+  ])('rehydrates %s evidence with the current %s classification', (activityType, activityGroup) => {
+    const stale = {
+      ...createCurrentEvidence(),
+      activityType,
+      activityGroup: ActivityTypeGroups.UnspecifiedGroup
+    };
+
+    expect(normalizeThreeDimensionalStrainEvidenceValue(stale)).toEqual({
+      ...stale,
+      activityGroup
+    });
   });
 
   it.each([

--- a/src/events/utilities/activity-durability.spec.ts
+++ b/src/events/utilities/activity-durability.spec.ts
@@ -277,18 +277,21 @@ describe('activity durability', () => {
     );
   });
 
-  it('keeps unsupported activities out of the persisted metric', () => {
-    const result = analyzeActivityDurability(
-      mockActivity({
-        type: ActivityTypes.WeightTraining,
-        streams: {
-          [DataPower.type]: Array(3600).fill(200),
-          [DataHeartRate.type]: Array(3600).fill(130)
-        }
-      })
-    );
-    expect(result).toEqual({ timeline: [], summary: null });
-  });
+  it.each([ActivityTypes.WeightTraining, ActivityTypes.Driving, ActivityTypes.Wheelchair])(
+    'keeps %s out of the persisted durability metric',
+    type => {
+      const result = analyzeActivityDurability(
+        mockActivity({
+          type,
+          streams: {
+            [DataPower.type]: Array(3600).fill(200),
+            [DataHeartRate.type]: Array(3600).fill(130)
+          }
+        })
+      );
+      expect(result).toEqual({ timeline: [], summary: null });
+    }
+  );
 
   it('compares like-for-like active pool lengths', () => {
     const lengths = Array.from({ length: 72 }, (_, index) =>

--- a/src/events/utilities/activity.utilities.ts
+++ b/src/events/utilities/activity.utilities.ts
@@ -2696,6 +2696,13 @@ export class ActivityUtilities {
     return activity.type === ActivityTypes.TrackAndField;
   }
 
+  private static supportsCalculatedTrainingStressScore(activity: ActivityInterface): boolean {
+    const activityGroup = ActivityTypesHelper.getActivityGroupForActivityType(activity.type);
+    return (
+      activityGroup !== ActivityTypeGroups.MotorizedGroup && activityGroup !== ActivityTypeGroups.AdaptiveMobilityGroup
+    );
+  }
+
   private static calculateTrainingStressScoreByPriority(activity: ActivityInterface): TssCalculationResult | null {
     const powerTss = this.calculatePowerTss(activity);
     if (powerTss) {
@@ -2745,6 +2752,23 @@ export class ActivityUtilities {
 
   private static generateTrainingStressScore(activity: ActivityInterface): void {
     const existingTss = this.getFiniteStatValue(activity, DataTrainingStressScore.type);
+
+    if (!this.supportsCalculatedTrainingStressScore(activity)) {
+      const existingTssMethod = activity.getStat(DataTrainingStressScoreMethod.type)?.getValue();
+      const hasImportedTss =
+        existingTss !== null &&
+        (existingTssMethod === undefined || existingTssMethod === TrainingStressScoreMethod.IMPORTED);
+      if (hasImportedTss) {
+        if (existingTssMethod === undefined) {
+          this.setTrainingStressScoreMethod(activity, TrainingStressScoreMethod.IMPORTED);
+        }
+      } else {
+        activity.removeStat(DataTrainingStressScore.type);
+        activity.removeStat(DataTrainingStressScoreMethod.type);
+      }
+      return;
+    }
+
     const preserveImportedTss = activity.parseOptions?.tss?.preserveImportedTss ?? true;
 
     if (existingTss !== null && preserveImportedTss) {

--- a/src/events/utilities/training-stress-score.integration.spec.ts
+++ b/src/events/utilities/training-stress-score.integration.spec.ts
@@ -249,6 +249,61 @@ describe('Training Stress Score integration', () => {
     expect(activity.getStat(DataTrainingStressScoreMethod.type)?.getValue()).toBe(TrainingStressScoreMethod.IMPORTED);
   });
 
+  it.each([ActivityTypes.Driving, ActivityTypes.Wheelchair])(
+    'does not calculate TSS for %s even when power inputs are available',
+    activityType => {
+      const activity = createActivity(
+        activityType,
+        1200,
+        new ActivityParsingOptions({
+          tss: {
+            preserveImportedTss: false,
+            overrides: {
+              functionalThresholdPower: 250
+            }
+          }
+        })
+      );
+      addNumericStream(activity, DataPower.type, new Array(1200).fill(250));
+
+      ActivityUtilities.generateMissingStreamsAndStatsForActivity(activity);
+
+      expect(activity.getStat(DataTrainingStressScore.type)).toBeUndefined();
+      expect(activity.getStat(DataTrainingStressScoreMethod.type)).toBeUndefined();
+    }
+  );
+
+  it.each([ActivityTypes.Driving, ActivityTypes.Wheelchair])(
+    'preserves imported TSS for %s even when imported-TSS preservation is disabled',
+    activityType => {
+      const activity = createActivity(
+        activityType,
+        1200,
+        new ActivityParsingOptions({ tss: { preserveImportedTss: false } })
+      );
+      activity.addStat(new DataTrainingStressScore(42.5));
+
+      ActivityUtilities.generateMissingStreamsAndStatsForActivity(activity);
+
+      expect(activity.getStat(DataTrainingStressScore.type)?.getValue()).toBe(42.5);
+      expect(activity.getStat(DataTrainingStressScoreMethod.type)?.getValue()).toBe(TrainingStressScoreMethod.IMPORTED);
+    }
+  );
+
+  it.each([ActivityTypes.Driving, ActivityTypes.Wheelchair])(
+    'removes stale calculated TSS for %s after its group no longer supports calculation',
+    activityType => {
+      const activity = createActivity(activityType, 1200);
+      activity.addStat(new DataTrainingStressScore(42.5));
+      activity.addStat(new DataTrainingStressScoreMethod(TrainingStressScoreMethod.POWER));
+
+      ActivityUtilities.generateMissingStreamsAndStatsForActivity(activity);
+
+      expect(activity.getStat(DataTrainingStressScore.type)).toBeUndefined();
+      expect(activity.getStat(DataTrainingStressScoreMethod.type)).toBeUndefined();
+    }
+  );
+
   it('recomputes imported TSS when preserveImportedTss is disabled', () => {
     const activity = createActivity(
       ActivityTypes.Cycling,


### PR DESCRIPTION
## Summary
- classify the 43 concrete fallback activity types into existing or new families while retaining eight intentional generic/structural fallbacks
- add Skating, Aerial Sports, Motorized, and Adaptive Mobility groups; keep Ice Skating in Winter Sports and Fitness Equipment indoors
- derive aerial vertical-speed units and prevent calculated TSS/durability for Motorized and Adaptive Mobility while retaining imported TSS
- bump the package minor version from 20.1.1 to 20.2.0

## Validation
- `npm test -- --runInBand` (105 suites, 1,928 tests passed)
- `npm run build`
- `npm run docs:build`
- `npm pack --dry-run --json`